### PR TITLE
fix installation issues & fix broken tests

### DIFF
--- a/lib/vsc/mympirun/option.py
+++ b/lib/vsc/mympirun/option.py
@@ -30,7 +30,7 @@ import os
 from vsc.mympirun.mpi.mpi import MPI
 from vsc.utils import fancylogger
 from vsc.utils.generaloption import GeneralOption
-from vsc.utils.missing import get_subclasses, nub
+from vsc.utils.missing import get_subclasses
 # introduce usage / -u option. (original has -h for --hybrid)
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,13 +32,14 @@ Setup for mympirun
 import os
 import pkgutil
 import sys
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'lib'))
-
 import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import vsc_setup, log, sdw
-import vsc.mympirun.mpi.mpi as mpim
-from vsc.utils.missing import get_subclasses
+
+
+# hardcoded list, to avoid ugly hacks in order to be able to import from vsc.mympirun in setup.py...
+# this list is checked to be synced via a dedicated unit test
+MYMPIRUN_ALIASES = ['ihmpirun', 'ihmpirun', 'impirun', 'impirun', 'm2hmpirun', 'm2mpirun', 'mhmpirun',
+                    'mmpirun', 'ompirun', 'ompirun']
 
 PACKAGE = {
     'install_requires': [
@@ -71,14 +72,6 @@ class mympirun_vsc_install_scripts(vsc_setup.vsc_install_scripts):
         for loader, modulename, _ in pkgutil.walk_packages([os.path.dirname(mpim.__file__)]):
             loader.find_module(modulename).load_module(modulename)
 
-        mympirun_aliases = []
-
-        for mpiclass in get_subclasses(mpim.MPI):
-            mympirun_aliases += mpiclass._mpiscriptname_for
-
-        mympirun_aliases += ['myscoop']
-
-
         log.info("mympirun_vsc_install_scripts %s", mpim)
         # old-style class
         vsc_setup.vsc_install_scripts.run(self)
@@ -98,7 +91,7 @@ class mympirun_vsc_install_scripts(vsc_setup.vsc_install_scripts):
                 os.chdir(rel_script_dir)
 
                 # create symlinks that point to mympirun for all mpirun aliases
-                for sym_name in mympirun_aliases:
+                for sym_name in MYMPIRUN_ALIASES:
                     if os.path.exists(sym_name):
                         os.remove(sym_name)
                     os.symlink(rel_script, sym_name)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ from vsc.install.shared_setup import vsc_setup, log, sdw
 
 # hardcoded list, to avoid ugly hacks in order to be able to import from vsc.mympirun in setup.py...
 # this list is checked to be synced via a dedicated unit test
-MYMPIRUN_ALIASES = ['ihmpirun', 'impirun', 'm2hmpirun', 'm2mpirun', 'mhmpirun', 'mmpirun', 'ompirun']
+MYMPIRUN_ALIASES = ['ihmpirun', 'impirun', 'm2hmpirun', 'm2mpirun', 'mhmpirun', 'mmpirun', 'myscoop', 'ompirun']
 
 PACKAGE = {
     'install_requires': [

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ PACKAGE = {
         'vsc-install >= 0.10.9', # for modified subclassing
         'IPy',
     ],
-    'name': 'vsc-mympirun',
     'version': '3.4.4',
     'author': [sdw],
     'maintainer': [sdw],

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ PACKAGE = {
         'vsc-install >= 0.10.9', # for modified subclassing
         'IPy',
     ],
+    'name': 'vsc-mympirun',
     'version': '3.4.4',
     'author': [sdw],
     'maintainer': [sdw],

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,7 @@ from vsc.install.shared_setup import vsc_setup, log, sdw
 
 # hardcoded list, to avoid ugly hacks in order to be able to import from vsc.mympirun in setup.py...
 # this list is checked to be synced via a dedicated unit test
-MYMPIRUN_ALIASES = ['ihmpirun', 'ihmpirun', 'impirun', 'impirun', 'm2hmpirun', 'm2mpirun', 'mhmpirun',
-                    'mmpirun', 'ompirun', 'ompirun']
+MYMPIRUN_ALIASES = ['ihmpirun', 'impirun', 'm2hmpirun', 'm2mpirun', 'mhmpirun', 'mmpirun', 'ompirun']
 
 PACKAGE = {
     'install_requires': [

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ Setup for mympirun
 import os
 import pkgutil
 import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'lib'))
+
 import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import vsc_setup, log, sdw
 import vsc.mympirun.mpi.mpi as mpim

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -223,8 +223,8 @@ class TestMPI(unittest.TestCase):
         print("localhosts: %s" % res)
 
         for (nodename, interface) in res:
-            self.assertTrue(nodename in mpi_instance.uniquenodes,
-                            msg="%s is not a node from the uniquenodes list" % nodename)
+            self.assertTrue(nodename in mpi_instance.nodes,
+                            msg="%s is not a node from the nodes list" % nodename)
             self.assertTrue(interface in out,
                             msg="%s can not be found in the output of `/sbin/ip -4 -o addr show`, output: %s" %
                             (interface, out))

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -280,10 +280,8 @@ class TestMPI(unittest.TestCase):
         from setup import MYMPIRUN_ALIASES
 
         # make sure all modules in vsc.mympirun.mpi are imported
-        topdir = os.path.dirname(os.path.dirname(os.path.dirname(mpim.__file__)))
-        for loader, modname, _ in pkgutil.walk_packages([topdir]):
-            if modname.startswith('vsc.mympirun.mpi'):
-                loader.find_module(modname).load_module(modname)
+        for loader, modname, _ in pkgutil.walk_packages([os.path.dirname(mpim.__file__)]):
+            loader.find_module(modname).load_module(modname)
 
         # determine actual list of mympirun aliases
         mympirun_aliases = ['myscoop']

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -280,8 +280,10 @@ class TestMPI(unittest.TestCase):
         from setup import MYMPIRUN_ALIASES
 
         # make sure all modules in vsc.mympirun.mpi are imported
-        for loader, modname, _ in pkgutil.walk_packages([os.path.dirname(mpim.__file__)]):
-            loader.find_module(modname).load_module(modname)
+        topdir = os.path.dirname(os.path.dirname(os.path.dirname(mpim.__file__)))
+        for loader, modname, _ in pkgutil.walk_packages([topdir]):
+            if modname.startswith('vsc.mympirun.mpi'):
+                loader.find_module(modname).load_module(modname)
 
         # determine actual list of mympirun aliases
         mympirun_aliases = ['myscoop']

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -26,9 +26,11 @@
 Tests for the vsc.mympirun.mpi.mpi module.
 
 @author: Jeroen De Clerck
+@author: Kenneth Hoste (HPC-UGent)
 """
 from IPy import IP
 import os
+import pkgutil
 import re
 import stat
 import string
@@ -271,3 +273,18 @@ class TestMPI(unittest.TestCase):
         print("cmdargs: %s" % inst.cmdargs)
         for arg in inst.mpirun_cmd:
             self.assertTrue(arg in argspool, msg="arg: %s, pool: %s" % (arg, argspool))
+
+    def test_mympirun_aliases_setup(self):
+        """Make sure that list of mympirun aliases included in setup.py is synced"""
+        from setup import MYMPIRUN_ALIASES
+
+        # make sure all modules in vsc.mympirun.mpi are imported
+        for loader, modname, _ in pkgutil.walk_packages([os.path.dirname(mpim.__file__)]):
+            loader.find_module(modname).load_module(modname)
+
+        # determine actual list of mympirun aliases
+        mympirun_aliases = []
+        for mpiclass in get_subclasses(mpim.MPI):
+            mympirun_aliases.extend(mpiclass._mpiscriptname_for)
+
+        self.assertEqual(MYMPIRUN_ALIASES, sorted(mympirun_aliases))

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -35,6 +35,8 @@ import re
 import stat
 import string
 import unittest
+from vsc.utils.run import run_simple
+from vsc.utils.missing import get_subclasses
 
 from vsc.mympirun.factory import getinstance
 import vsc.mympirun.mpi.mpi as mpim
@@ -42,7 +44,6 @@ from vsc.mympirun.mpi.openmpi import OpenMPI
 from vsc.mympirun.mpi.intelmpi import IntelMPI
 from vsc.mympirun.option import MympirunOption
 from vsc.mympirun.rm.local import Local
-from vsc.utils.run import run_simple
 
 # we wish to use the mpirun we ship
 os.environ["PATH"] = os.path.dirname(os.path.realpath(__file__)) + os.pathsep + os.environ["PATH"]

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -36,7 +36,7 @@ import stat
 import string
 import unittest
 from vsc.utils.run import run_simple
-from vsc.utils.missing import get_subclasses
+from vsc.utils.missing import get_subclasses, nub
 
 from vsc.mympirun.factory import getinstance
 import vsc.mympirun.mpi.mpi as mpim
@@ -288,4 +288,4 @@ class TestMPI(unittest.TestCase):
         for mpiclass in get_subclasses(mpim.MPI):
             mympirun_aliases.extend(mpiclass._mpiscriptname_for)
 
-        self.assertEqual(MYMPIRUN_ALIASES, sorted(mympirun_aliases))
+        self.assertEqual(MYMPIRUN_ALIASES, nub(sorted(mympirun_aliases)))

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -284,7 +284,7 @@ class TestMPI(unittest.TestCase):
             loader.find_module(modname).load_module(modname)
 
         # determine actual list of mympirun aliases
-        mympirun_aliases = []
+        mympirun_aliases = ['myscoop']
         for mpiclass in get_subclasses(mpim.MPI):
             mympirun_aliases.extend(mpiclass._mpiscriptname_for)
 

--- a/test/sched.py
+++ b/test/sched.py
@@ -78,13 +78,13 @@ class TestSched(unittest.TestCase):
 
     def test_core_on_this_node(self):
         """
-        test if core_on_this_node() sets foundppn to an integer
+        test if core_on_this_node() sets cores_per_node to an integer
 
         core_on_this_node() gets called by the __init__ of getinstance()
         """
         for _, val in SCHEDDICT.iteritems():
             inst = getinstance(mpim.MPI, val, MympirunOption())
-            self.assertTrue(isinstance(inst.foundppn, int))
+            self.assertTrue(isinstance(inst.cores_per_node, int))
 
     def test_which_cpus(self):
         """
@@ -104,15 +104,4 @@ class TestSched(unittest.TestCase):
         """
         inst = getinstance(mpim.MPI, Local, MympirunOption())
         self.assertEqual(set(inst.nodes), set(['localhost']))
-        self.assertEqual(len(inst.cpus), inst.nrnodes)
-
-    def test_get_unique_nodes(self):
-        """
-        test if get_unique_nodes() sets uniquenodes to the unique elements of nodes
-
-        get_unique_nodes() gets called by the __init__ of getinstance()
-        """
-        for _, val in SCHEDDICT.iteritems():
-            inst = getinstance(mpim.MPI, val, MympirunOption())
-            self.assertEqual(set(inst.uniquenodes), set(inst.nodes))
-            self.assertEqual(inst.nruniquenodes, len(set(inst.nodes)))
+        self.assertEqual(len(inst.cpus), len(inst.nodes))


### PR DESCRIPTION
this was overlooked in #73 when fixing #50

without this, `setup.py install` fails as below unless the path to `/lib` is already in `$PYTHONPATH`

```
INFO: This is (based on) vsc.install.shared_setup 0.10.14
Traceback (most recent call last):
  File "setup.py", line 40, in <module>
    import vsc.mympirun.mpi.mpi as mpim
ImportError: No module named mympirun.mpi.mpi
```