### PR TITLE
fix version checks for Intel MPI, fix check for local usage, change mpirun check using $EBROOT* and $EBVERSION*, avoid use of --setmpi in end2end tests

### DIFF
--- a/lib/vsc/mympirun/mpi/intelmpi.py
+++ b/lib/vsc/mympirun/mpi/intelmpi.py
@@ -33,7 +33,7 @@ import os
 import socket
 import tempfile
 
-from vsc.mympirun.mpi.mpi import MPI, which
+from vsc.mympirun.mpi.mpi import MPI, version_in_range, which
 from vsc.utils.missing import nub
 
 SCALABLE_PROGRESS_LOWER_THRESHOLD = 64
@@ -205,7 +205,7 @@ class IntelHydraMPI(IntelMPI):
 
     _mpiscriptname_for = ['ihmpirun']
 
-    _mpirun_version = staticmethod(lambda x: LooseVersion(x) >= LooseVersion("4.1.0.0"))
+    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '4.1.0.0', '5.0.3'))
 
     HYDRA = True
     HYDRA_LAUNCHER_NAME = "bootstrap"
@@ -252,5 +252,5 @@ class IntelHydraMPIPbsdsh(IntelHydraMPI):
     """ MPI class for IntelMPI, with hydra and supporting pbsdsh """
     # pbsdsh is supported from Intel MPI 5.0.3:
     # https://software.intel.com/sites/default/files/managed/b7/99/intelmpi-5.0-update3-releasenotes-linux.pdf
-    _mpirun_version = staticmethod(lambda x: LooseVersion(x) >= LooseVersion("5.0.3"))
+    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '5.0.3', None))
     HYDRA_LAUNCHER = 'pbsdsh'

--- a/lib/vsc/mympirun/mpi/intelmpi.py
+++ b/lib/vsc/mympirun/mpi/intelmpi.py
@@ -52,7 +52,7 @@ class IntelMPI(MPI):
     """An implementation of the MPI class for IntelMPI"""
 
     _mpiscriptname_for = ['impirun']
-    _mpirun_for = ['impi']
+    _mpirun_for = 'impi'
     _mpirun_version = staticmethod(lambda ver: version_in_range(ver, None, '4.1.0.0'))
 
     RUNTIMEOPTION = {

--- a/lib/vsc/mympirun/mpi/intelmpi.py
+++ b/lib/vsc/mympirun/mpi/intelmpi.py
@@ -252,4 +252,5 @@ class IntelHydraMPIPbsdsh(IntelHydraMPI):
     # pbsdsh is supported from Intel MPI 5.0.3:
     # https://software.intel.com/sites/default/files/managed/b7/99/intelmpi-5.0-update3-releasenotes-linux.pdf
     _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '5.0.3', None))
+    HYDRA = True
     HYDRA_LAUNCHER = 'pbsdsh'

--- a/lib/vsc/mympirun/mpi/intelmpi.py
+++ b/lib/vsc/mympirun/mpi/intelmpi.py
@@ -28,7 +28,6 @@ Intel MPI specific class
 Documentation can be found at https://software.intel.com/en-us/node/528769
 """
 
-from distutils.version import LooseVersion
 import os
 import socket
 import tempfile
@@ -54,7 +53,7 @@ class IntelMPI(MPI):
 
     _mpiscriptname_for = ['impirun']
     _mpirun_for = ['impi']
-    _mpirun_version = staticmethod(lambda x: LooseVersion(x) < LooseVersion("4.1.0.0"))
+    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, None, '4.1.0.0'))
 
     RUNTIMEOPTION = {
         'options': {

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -349,7 +349,7 @@ class MPI(object):
         reg = re.compile(r"(?:%s)%s(\d+(?:(?:\.|-)\d+(?:(?:\.|-)\d+\S+)?)?)" %
                          ("|".join(cls._mpirun_for), os.sep))
         reg_match = reg.search(mpirun_path)
-        LOGGER.debug("_is_mpisrun_for(), reg_match: %s", reg_match)
+        LOGGER.debug("_is_mpirun_for(), reg_match: %s", reg_match)
 
         if reg_match:
             if cls._mpirun_version is None:
@@ -864,7 +864,7 @@ class MPI(object):
             else:
                 self.log.raiseException("There is no launcher specified, and no default launcher found")
 
-        if launcher != 'local':
+        if not self.isLocal():
             self.mpiexec_options.append("-%s %s" % (self.HYDRA_LAUNCHER_NAME, launcher))
 
         # when using ssh launcher, use custom pbsssh wrapper as exec

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -263,7 +263,7 @@ class MPI(object):
 
     RUNTIMEOPTION = None
 
-    _mpirun_for = []
+    _mpirun_for = None
     _mpiscriptname_for = []
     _mpirun_version = None
 
@@ -342,13 +342,18 @@ class MPI(object):
         @param cls: the class that calls this function
         @return: true if $EBVERSION is defined as an mpirun implementation of $cls
         """
+        version = True
+        if cls._mpirun_for:
+            vs = os.getenv('EBVERSION' + cls._mpirun_for.upper())
+            if hasattr(cls, '_mpirun_version'):
+                LOGGER.debug("no mpirun version provided, skipping version check")
+            elif vs:
+                LOGGER.DEBUG("found EBVERSION%s: %s" % (cls._mpirun_for.upper(), vs))
+                version = cls._mpirun_version(vs)
+            else:
+                LOGGER.debug("environment variable EBVERSION%s not found, skipping version check" % cls._mpirun_for)
 
-        vs = os.getenv('EBVERSION' + cls._mpirun_for.upper())
-        if vs:
-            return cls._mpirun_version(vs)
-        else:
-            LOGGER.debug("no mpirun version provided, skipping version check")
-            return True
+        return version
 
 
     @classmethod

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -342,17 +342,16 @@ class MPI(object):
         @param cls: the class that calls this function
         @return: true if $EBVERSION is defined as an mpirun implementation of $cls
         """
-        version = True
+        version = False
         if cls._mpirun_for:
             vs = os.getenv('EBVERSION' + cls._mpirun_for.upper())
-            if hasattr(cls, '_mpirun_version'):
+            if not hasattr(cls, '_mpirun_version'):
                 LOGGER.debug("no mpirun version provided, skipping version check")
             elif vs:
-                LOGGER.DEBUG("found EBVERSION%s: %s" % (cls._mpirun_for.upper(), vs))
+                LOGGER.debug("found EBVERSION%s: %s" % (cls._mpirun_for.upper(), vs))
                 version = cls._mpirun_version(vs)
             else:
                 LOGGER.debug("environment variable EBVERSION%s not found, skipping version check" % cls._mpirun_for)
-
         return version
 
 

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -42,8 +42,8 @@ import subprocess
 import sys
 import time
 
+from distutils.version import LooseVersion
 from IPy import IP
-
 from vsc.utils.fancylogger import getLogger
 from vsc.utils.missing import get_subclasses, nub
 from vsc.utils.run import Run, RunAsyncLoopStdout, RunFile, RunLoop, run_simple
@@ -144,6 +144,7 @@ def stripfake():
     LOGGER.debug("PATH after stripfake(): %s", os.environ['PATH'])
     return
 
+
 def which(cmd):
     """
     Return (first) path in $PATH for specified command, or None if command is not found.
@@ -159,6 +160,22 @@ def which(cmd):
             return cmd_path
     LOGGER.warning("Could not find command '%s' (with permissions to read/execute it) in $PATH (%s)", cmd, paths)
     return None
+
+
+def version_in_range(version, lower_limit, upper_limit):
+    """
+    Check whether version is in specified range
+
+    :param lower_limit: lower limit for version (inclusive), no lower limit if None
+    :param upper_limit: upper limit for version (exclusive), no upper limit if None
+    """
+    in_range = True
+    if lower_limit is not None and LooseVersion(version) < LooseVersion(lower_limit):
+        in_range = False
+    if upper_limit is not None and LooseVersion(version) >= LooseVersion(upper_limit):
+        in_range = False
+    return in_range
+
 
 class RunMPI(Run):
     """

--- a/lib/vsc/mympirun/mpi/mpich.py
+++ b/lib/vsc/mympirun/mpi/mpich.py
@@ -29,9 +29,7 @@ Documentation can be found at https://www.mpich.org/documentation/guides/
 """
 import os
 
-from distutils.version import LooseVersion
-
-from vsc.mympirun.mpi.mpi import MPI
+from vsc.mympirun.mpi.mpi import MPI, version_in_range
 from vsc.utils.run import run_simple
 from vsc.utils.missing import nub
 
@@ -41,7 +39,7 @@ class MVAPICH2Hydra(MPI):
 
     _mpiscriptname_for = ['mhmpirun']
     _mpirun_for = ['MVAPICH2']
-    _mpirun_version = staticmethod(lambda x: LooseVersion(x) >= LooseVersion("1.6.0"))
+    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '1.6.0', None))
 
     HYDRA = True
 
@@ -81,7 +79,7 @@ class MVAPICH2(MVAPICH2Hydra):
     """
     _mpiscriptname_for = ['mmpirun']
     _mpirun_for = ['MVAPICH2']
-    _mpirun_version = staticmethod(lambda x: LooseVersion(x) < LooseVersion("1.6.0"))
+    staticmethod(lambda ver: version_in_range(ver, None, '1.6.0'))
 
     HYDRA = False
 
@@ -116,7 +114,7 @@ class MPICH2Hydra(MVAPICH2Hydra):
 
     _mpiscriptname_for = ['m2hmpirun']
     _mpirun_for = ['MPICH2', 'mpich2']
-    _mpirun_version = staticmethod(lambda x: LooseVersion(x) >= LooseVersion("1.4.0"))
+    staticmethod(lambda ver: version_in_range(ver, '1.4.0', None))
 
     OPTS_FROM_ENV_FLAVOR_PREFIX = ['MPICH']
 
@@ -134,7 +132,7 @@ class MPICH2(MVAPICH2):
 
     _mpiscriptname_for = ['m2mpirun']
     _mpirun_for = ['MPICH2', 'mpich2']
-    _mpirun_version = staticmethod(lambda x: LooseVersion(x) < LooseVersion("1.4.0"))
+    staticmethod(lambda ver: version_in_range(ver, None, '1.4.0'))
 
     OPTS_FROM_ENV_FLAVOR_PREFIX = ['MPICH']
 

--- a/lib/vsc/mympirun/mpi/mpich.py
+++ b/lib/vsc/mympirun/mpi/mpich.py
@@ -38,7 +38,7 @@ class MVAPICH2Hydra(MPI):
     """An implementation of the MPI class for MVAPICH2 with Hydra"""
 
     _mpiscriptname_for = ['mhmpirun']
-    _mpirun_for = ['MVAPICH2']
+    _mpirun_for = 'MVAPICH2'
     _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '1.6.0', None))
 
     HYDRA = True
@@ -78,7 +78,7 @@ class MVAPICH2(MVAPICH2Hydra):
       - it uses the hydra interface and sligthly other mpdboot
     """
     _mpiscriptname_for = ['mmpirun']
-    _mpirun_for = ['MVAPICH2']
+    _mpirun_for = 'MVAPICH2'
     staticmethod(lambda ver: version_in_range(ver, None, '1.6.0'))
 
     HYDRA = False
@@ -113,7 +113,7 @@ class MPICH2Hydra(MVAPICH2Hydra):
     """An implementation of the MPI class for MPICH2 with Hydra"""
 
     _mpiscriptname_for = ['m2hmpirun']
-    _mpirun_for = ['MPICH2', 'mpich2']
+    _mpirun_for = 'MPICH2'
     staticmethod(lambda ver: version_in_range(ver, '1.4.0', None))
 
     OPTS_FROM_ENV_FLAVOR_PREFIX = ['MPICH']
@@ -131,7 +131,7 @@ class MPICH2(MVAPICH2):
     """An implementation of the MPI class for MPICH2"""
 
     _mpiscriptname_for = ['m2mpirun']
-    _mpirun_for = ['MPICH2', 'mpich2']
+    _mpirun_for = 'MPICH2'
     staticmethod(lambda ver: version_in_range(ver, None, '1.4.0'))
 
     OPTS_FROM_ENV_FLAVOR_PREFIX = ['MPICH']

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -37,7 +37,7 @@ class OpenMPI(MPI):
     """An implementation of the MPI class for OpenMPI"""
 
     _mpiscriptname_for = ['ompirun']
-    _mpirun_for = ['OpenMPI']
+    _mpirun_for = 'OpenMPI'
 
     DEVICE_MPIDEVICE_MAP = {'ib': 'sm,openib,self', 'det': 'sm,tcp,self', 'shm': 'sm,self', 'socket': 'sm,tcp,self'}
 

--- a/lib/vsc/mympirun/rm/local.py
+++ b/lib/vsc/mympirun/rm/local.py
@@ -51,3 +51,9 @@ class Local(Sched):
         self.nodes = [localhostname] * len(self.cpus)
 
         self.log.debug("set_nodes: %s", self.nodes)
+
+    def isLocal(self):
+        """
+        Returns True if scheduler is local.
+        """
+        return True

--- a/lib/vsc/mympirun/rm/local.py
+++ b/lib/vsc/mympirun/rm/local.py
@@ -52,7 +52,7 @@ class Local(Sched):
 
         self.log.debug("set_nodes: %s", self.nodes)
 
-    def isLocal(self):
+    def is_local(self):
         """
         Returns True if scheduler is local.
         """

--- a/lib/vsc/mympirun/rm/sched.py
+++ b/lib/vsc/mympirun/rm/sched.py
@@ -288,7 +288,7 @@ class Sched(object):
 
         self.mpinodes = res
 
-    def isLocal(self):
+    def is_local(self):
         """
         Only returns True if scheduler is local.
         """

--- a/lib/vsc/mympirun/rm/sched.py
+++ b/lib/vsc/mympirun/rm/sched.py
@@ -287,3 +287,9 @@ class Sched(object):
             self.log.raiseException("set_mpinodes unknown ordermode %s" % ordermode)
 
         self.mpinodes = res
+
+    def isLocal(self):
+        """
+        Only returns True if scheduler is local.
+        """
+        return False

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -150,7 +150,7 @@ class TestMPI(TestCase):
             print("mpiscriptname: %s, path: %s, instance mpirun for: %s" %
                   (instance._mpiscriptname_for, val,
                    instance._mpirun_for))
-            self.assertTrue(instance._is_mpirun_for(val),
+            self.assertTrue(instance._is_mpirun_for(),
                             msg="mpi instance is not an MPI flavor defined by %s according to _is_mpirun_for, path: %s" %
                             (key, val))
 

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -364,3 +364,15 @@ class TestMPI(TestCase):
             basepaths.add(inst.mympirundir)
 
         self.assertEqual(len(basepaths), 10)
+
+
+    def test_version_in_range(self):
+        """Test version_in_range function"""
+        self.assertTrue(mpim.version_in_range('1.4.0', '1.2.0', '2.0'))
+        self.assertTrue(mpim.version_in_range('1.4.0', '1.2.0', None))
+        self.assertTrue(mpim.version_in_range('1.4.0', None, '2.0'))
+        self.assertTrue(mpim.version_in_range('1.4.0', None, None)) # always true
+
+        self.assertFalse(mpim.version_in_range('1.4.0', '1.6.0', '2.0'))
+        self.assertFalse(mpim.version_in_range('1.4.0', '1.6.0', None))
+        self.assertFalse(mpim.version_in_range('2.4.0', None, '2.0'))

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -44,7 +44,7 @@ from vsc.utils.missing import get_subclasses, nub
 from vsc.mympirun.factory import getinstance
 import vsc.mympirun.mpi.mpi as mpim
 from vsc.mympirun.mpi.openmpi import OpenMPI
-from vsc.mympirun.mpi.intelmpi import IntelMPI
+from vsc.mympirun.mpi.intelmpi import IntelMPI, IntelHydraMPIPbsdsh
 from vsc.mympirun.option import MympirunOption
 from vsc.mympirun.rm.local import Local
 
@@ -137,22 +137,17 @@ class TestMPI(TestCase):
 
     def test_is_mpirun_for(self):
         """test if _is_mpirun_for returns true when it is given the path of its executable"""
-        optionparser = MympirunOption()
+        impi_instance = getinstance(IntelMPI, Local, MympirunOption())
+        # EBVERSION not set
+        self.assertFalse(impi_instance._is_mpirun_for(), "")
+        os.environ['EBVERSIONIMPI'] = '4.0.1'
+        self.assertTrue(impi_instance._is_mpirun_for(), "")
+        os.environ['EBVERSIONIMPI'] = '5.1.3'
+        self.assertFalse(impi_instance._is_mpirun_for(), "")
 
-        mpidict = {
-            IntelMPI: "/apps/gent/SL6/sandybridge/software/impi/3.2.2.006/bin64/mpirun",
-            OpenMPI: "apps/gent/SL6/sandybridge/software/OpenMPI/1.8.8-GNU-4.9.3-2.25/bin/mpirun",
-        }
+        impi_instance = getinstance(IntelHydraMPIPbsdsh, Local, MympirunOption())
+        self.assertTrue(impi_instance._is_mpirun_for(), "")
 
-        for key, val in mpidict.iteritems():
-            instance = getinstance(key, Local, optionparser)
-
-            print("mpiscriptname: %s, path: %s, instance mpirun for: %s" %
-                  (instance._mpiscriptname_for, val,
-                   instance._mpirun_for))
-            self.assertTrue(instance._is_mpirun_for(),
-                            msg="mpi instance is not an MPI flavor defined by %s according to _is_mpirun_for, path: %s" %
-                            (key, val))
 
     def test_set_omp_threads(self):
         """test if OMP_NUM_THREAD gets set correctly"""

--- a/test/sched.py
+++ b/test/sched.py
@@ -72,8 +72,13 @@ def cleanup_PBS_env(orig_env):
     os.chmod(os.environ['PBS_NODEFILE'], stat.S_IWUSR)
     os.chmod(os.path.dirname(os.environ['PBS_NODEFILE']), stat.S_IWUSR|stat.S_IRUSR|stat.S_IXUSR)
     shutil.rmtree(os.path.dirname(os.environ['PBS_NODEFILE']))
-    os.environ = orig_env
 
+    # make sure that previously undefined variables are undefined
+    for key in os.environ.keys():
+        if key not in orig_env:
+            del os.environ[key]
+
+    os.environ = orig_env
 
 class TestSched(unittest.TestCase):
     """tests for vsc.mympirun.mpi.sched functions"""


### PR DESCRIPTION
wrt #114 