### PR TITLE
fix use of --universe with MPD as process manager (WIP)

### DIFF
--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -811,7 +811,8 @@ class MPI(object):
 
         # add the number of mpi processes (aka mpi universe) to mpdboot options
         if self.options.universe is not None and self.options.universe > 0 and not self.has_hydra:
-            self.mpdboot_options.append("--ncpus=%s" % self.get_universe_ncpus()[localmachine])
+            local_nodename = self.mpdboot_localhost_interface[0]
+            self.mpdboot_options.append("--ncpus=%s" % self.get_universe_ncpus()[local_nodename])
 
         # set verbosity
         if self.options.mpdbootverbose:

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ PACKAGE = {
         'vsc-install >= 0.10.25', # for modified subclassing
         'IPy',
     ],
-    'version': '4.0.1',
+    'version': '4.0.2',
     'author': [sdw],
     'maintainer': [sdw],
     'zip_safe': False,

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -90,7 +90,8 @@ class TestEnd2End(unittest.TestCase):
 
         # add /bin to $PATH, /lib to $PYTHONPATH
         self.topdir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        self.mympiscript = os.path.join(os.path.join(self.topdir, 'bin'), 'mympirun.py')
+        # needs to be wrapped in quotes since topdir could include spaces... 0_o
+        self.mympiscript = "'%s'" % os.path.join(os.path.join(self.topdir, 'bin'), 'mympirun.py')
         lib = os.path.join(self.topdir, 'lib')
         # make sure subshell finds .egg files by adding them to the pythonpath
         eggs = ':'.join(glob.glob(os.path.join(self.topdir, '.eggs', '*.egg')))


### PR DESCRIPTION
Using `--universe` when MPD is used as process manager currently results in:

```
Traceback (most recent call last):
  File "/prefix/bin/mympirun.py", line 124, in main
    instance.main()
  File "/prefix/lib/python2.7/site-packages/vsc/mympirun/mpi/mpi.py", line 417, in main
    self.make_mpdboot()
  File "/prefix/lib/python2.7/site-packages/vsc/mympirun/mpi/mpi.py", line 741, in make_mpdboot
    self.make_mpdboot_options()
  File "/prefix/lib/python2.7/site-packages/vsc_mympirun-4.0.1-py2.7.egg/vsc/mympirun/mpi/intelmpi.py", line 91, in make_mpdboot_options
    super(IntelMPI, self).make_mpdboot_options()
  File "/prefix/lib/python2.7/site-packages/vsc/mympirun/mpi/mpi.py", line 816, in make_mpdboot_options
    self.mpdboot_options.append("--ncpus=%s" % self.get_universe_ncpus()[localmachine])
UnboundLocalError: local variable 'localmachine' referenced before assignment
```