### PR TITLE
add support for --dry-run/-D option

### DIFF
--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -430,17 +430,17 @@ class MPI(object):
 
         run_kwargs = {
             'fatal_no_output': self.options.output_check_fatal,
-            'filename': None,
             'output_timeout': self.options.output_check_timeout,
         }
         if self.options.output:
             run_mpirun_cmd = RunFileLoopMPI.run
-            run_kwargs.update({'filename': self.options.output})
+            run_kwargs['filename'] = self.options.output
         else:
             run_mpirun_cmd = RunAsyncMPI.run
 
         if self.options.dry_run:
             self.log.info("Dry run, only printing generated mpirun command...")
+            run_kwargs['filename'] = None
             dry_run_output = '\n'.join([
                 "* output file            : %(filename)s",
                 "* output timeout         : %(output_timeout)s",

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -430,6 +430,7 @@ class MPI(object):
 
         run_kwargs = {
             'fatal_no_output': self.options.output_check_fatal,
+            'filename': None,
             'output_timeout': self.options.output_check_timeout,
         }
         if self.options.output:
@@ -437,7 +438,19 @@ class MPI(object):
             run_kwargs.update({'filename': self.options.output})
         else:
             run_mpirun_cmd = RunAsyncMPI.run
-        exitcode, _ = run_mpirun_cmd(self.mpirun_cmd, **run_kwargs)
+
+        if self.options.dry_run:
+            self.log.info("Dry run, only printing generated mpirun command...")
+            dry_run_output = '\n'.join([
+                "* output file            : %(filename)s",
+                "* output timeout         : %(output_timeout)s",
+                "* fail on missing output : %(fatal_no_output)s",
+                "* mpirun command         : %s" % ' '.join(self.mpirun_cmd),
+            ]) % run_kwargs
+            print(dry_run_output)
+            exitcode = 0
+        else:
+            exitcode, _ = run_mpirun_cmd(self.mpirun_cmd, **run_kwargs)
 
         self.cleanup()
 

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -440,17 +440,7 @@ class MPI(object):
 
         if self.options.dry_run:
             self.log.info("Dry run, only printing generated mpirun command...")
-
-            if 'filename' not in run_kwargs:
-                run_kwargs['filename'] = None
-
-            dry_run_output = '\n'.join([
-                "* output file            : %(filename)s",
-                "* output timeout         : %(output_timeout)s",
-                "* fail on missing output : %(fatal_no_output)s",
-                "* mpirun command         : %s" % ' '.join(self.mpirun_cmd),
-            ]) % run_kwargs
-            print(dry_run_output)
+            print(' '.join(self.mpirun_cmd))
             exitcode = 0
         else:
             exitcode, _ = run_mpirun_cmd(self.mpirun_cmd, **run_kwargs)

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -440,7 +440,10 @@ class MPI(object):
 
         if self.options.dry_run:
             self.log.info("Dry run, only printing generated mpirun command...")
-            run_kwargs['filename'] = None
+
+            if 'filename' not in run_kwargs:
+                run_kwargs['filename'] = None
+
             dry_run_output = '\n'.join([
                 "* output file            : %(filename)s",
                 "* output timeout         : %(output_timeout)s",

--- a/lib/vsc/mympirun/option.py
+++ b/lib/vsc/mympirun/option.py
@@ -72,6 +72,8 @@ class MympirunOption(GeneralOption):
 
             "debugmpi": ("Enable MPI level debugging", None, "store_true", False),
 
+            "dry-run": ("Dry run mode, just print command that will be executed", None, 'store_true', False, 'D'),
+
             "double": ("Run double the amount of processes (equivalent to --multi 2)", None, "store_true", False),
 
             "hybrid": ("Run in hybrid mode, specify number of processes per node.", "int", "store", None, 'h'),

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ PACKAGE = {
         'vsc-install >= 0.10.25', # for modified subclassing
         'IPy',
     ],
-    'version': '4.0.3',
+    'version': '4.0.4',
     'author': [sdw],
     'maintainer': [sdw],
     'zip_safe': False,

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -405,3 +405,29 @@ class TestEnd2End(unittest.TestCase):
         self.assertEqual(ec, 1)
         regex = r"OpenMPI 2\.0\.x uses a different naming protocol for nodes"
         self.assertTrue(re.search(regex, out), "mympirun should produce an error with ompi 2.0: %s" % out)
+
+    def test_dry_run(self):
+        """Test use of --dry-run/-D option."""
+        install_fake_mpirun('mpirun', self.tmpdir, 'impi', '5.1.2')
+
+        for dry_run_opt in ['--dry-run', '-D']:
+            ec, out = run_simple("%s %s %s hostname" % (sys.executable, self.mympiscript, dry_run_opt))
+            self.assertEqual(ec, 0)
+            patterns = [
+                r"\* output file\s*:\s*None$",
+                r"\* mpirun command\s*:\s*mpirun .* hostname$",
+            ]
+            for pattern in patterns:
+                regex = re.compile(pattern, re.M)
+                self.assertTrue(regex.search(out), "Pattern '%s' found in: %s" % (regex.pattern, out))
+
+            extra_opts = "--output foo --hybrid 9"
+            ec, out = run_simple("%s %s %s %s hostname" % (sys.executable, self.mympiscript, dry_run_opt, extra_opts))
+            self.assertEqual(ec, 0)
+            patterns = [
+                r"\* output file\s*:\s*foo$",
+                r"\* mpirun command\s*:\s*mpirun .* -np 9 .* hostname$",
+            ]
+            for pattern in patterns:
+                regex = re.compile(pattern, re.M)
+                self.assertTrue(regex.search(out), "Pattern '%s' found in: %s" % (regex.pattern, out))

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -413,21 +413,13 @@ class TestEnd2End(unittest.TestCase):
         for dry_run_opt in ['--dry-run', '-D']:
             ec, out = run_simple("%s %s %s hostname" % (sys.executable, self.mympiscript, dry_run_opt))
             self.assertEqual(ec, 0)
-            patterns = [
-                r"\* output file\s*:\s*None$",
-                r"\* mpirun command\s*:\s*mpirun .* hostname$",
-            ]
-            for pattern in patterns:
-                regex = re.compile(pattern, re.M)
-                self.assertTrue(regex.search(out), "Pattern '%s' found in: %s" % (regex.pattern, out))
 
-            extra_opts = "--output foo --hybrid 9"
+            regex = re.compile('^mpirun .* hostname$')
+            self.assertTrue(regex.search(out.strip()), "Pattern '%s' found in: %s" % (regex.pattern, out))
+
+            extra_opts = "--hybrid 9"
             ec, out = run_simple("%s %s %s %s hostname" % (sys.executable, self.mympiscript, dry_run_opt, extra_opts))
             self.assertEqual(ec, 0)
-            patterns = [
-                r"\* output file\s*:\s*foo$",
-                r"\* mpirun command\s*:\s*mpirun .* -np 9 .* hostname$",
-            ]
-            for pattern in patterns:
-                regex = re.compile(pattern, re.M)
-                self.assertTrue(regex.search(out), "Pattern '%s' found in: %s" % (regex.pattern, out))
+
+            regex = re.compile('^mpirun .* -np 9 .* hostname$')
+            self.assertTrue(regex.search(out.strip()), "Pattern '%s' found in: %s" % (regex.pattern, out))


### PR DESCRIPTION
Example output:

```
$ mympirun --dry-run hostname
* output file            : None
* output timeout         : 3600
* fail on missing output : False
* mpirun command         : mpirun --file=/user/home/gent/vsc400/vsc40023/.mympirun_azji3b/SCHED_Coupler2018030716483995592_20180307_164839/mpdboot --machinefile /user/home/gent/vsc400/vsc40023/.mympirun_azji3b/SCHED_Coupler2018030716483995592_20180307_164839/nodes -genv MKL_NUM_THREADS '1' -genv I_MPI_PIN '1' -genv I_MPI_DAT_LIBRARY 'libdat2.so' -genv I_MPI_FABRICS 'shm:dapl' -genv LOADEDMODULES 'cluster/delcatty:vsc-base/2.5.8:vsc-mympirun/dry_run:GCCcore/6.4.0:binutils/2.28-GCCcore-6.4.0:icc/2018.1.163-GCC-6.4.0-2.28:ifort/2018.1.163-GCC-6.4.0-2.28:iccifort/2018.1.163-GCC-6.4.0-2.28:impi/2018.1.163-iccifort-2018.1.163-GCC-6.4.0-2.28:iimpi/2018.01:imkl/2018.1.163-iimpi-2018.01:intel/2018.01' -genv I_MPI_FALLBACK_DEVICE '0' -genv I_MPI_FALLBACK 'disable' -genv I_MPI_NETMASK '10.143.0.0/255.255.0.0' -genv I_MPI_DAPL_SCALABLE_PROGRESS '0' -genv MODULESHOME '/usr/share/lmod/lmod' -genv MODULEPATH '/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/modules/all:/etc/modulefiles/vsc' -np 16 -envlist LD_LIBRARY_PATH,PATH,PYTHONPATH,I_MPI_MPD_TMPDIR,I_MPI_ROOT,OMP_NUM_THREADS,MKL_EXAMPLES hostname
```

(still WIP because needs version bump + enhanced tests)