### PR TITLE
add support for using mympirun on top of SLURM

### DIFF
--- a/lib/vsc/mympirun/mpi/intelmpi.py
+++ b/lib/vsc/mympirun/mpi/intelmpi.py
@@ -33,7 +33,7 @@ import socket
 import tempfile
 from vsc.utils.missing import nub
 
-from vsc.mympirun.mpi.mpi import MPI, version_in_range, which
+from vsc.mympirun.mpi.mpi import MPI, RM_HYDRA_LAUNCHER, version_in_range, which
 
 SCALABLE_PROGRESS_LOWER_THRESHOLD = 64
 
@@ -253,4 +253,4 @@ class IntelHydraMPIPbsdsh(IntelHydraMPI):
     # https://software.intel.com/sites/default/files/managed/b7/99/intelmpi-5.0-update3-releasenotes-linux.pdf
     _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '5.0.3', None))
 
-    HYDRA_LAUNCHER = 'pbsdsh'
+    HYDRA_LAUNCHER = RM_HYDRA_LAUNCHER

--- a/lib/vsc/mympirun/mpi/intelmpi.py
+++ b/lib/vsc/mympirun/mpi/intelmpi.py
@@ -232,7 +232,7 @@ class IntelHydraMPI(IntelMPI):
         if 'I_MPI_FABRICS' not in self.mpiexec_global_options:
             self.mpiexec_global_options['I_MPI_FABRICS'] = self.device
 
-        scalable_progress = (self.multiplier * len(self.nodes)) > SCALABLE_PROGRESS_LOWER_THRESHOLD
+        scalable_progress = (self.multiplier * self.nodes_tot_cnt) > SCALABLE_PROGRESS_LOWER_THRESHOLD
         self.mpiexec_global_options['I_MPI_DAPL_SCALABLE_PROGRESS'] = _one_zero(scalable_progress)
 
         if self.options.impi_daplud:

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -54,6 +54,8 @@ INSTALLATION_SUBDIRECTORY_NAME = '(VSC-tools|(?:vsc-)?mympirun)'
 # also hardcoded in setup.py !
 FAKE_SUBDIRECTORY_NAME = 'fake'
 
+RM_HYDRA_LAUNCHER = 'RM_HYDRA_LAUNCHER'
+
 # size of dir in bytes
 TEMPDIR_WARN_SIZE = 100000
 TEMPDIR_ERROR_SIZE = 1000000
@@ -922,8 +924,8 @@ class MPI(object):
             else:
                 self.log.raiseException("There is no launcher specified, and no default launcher found")
 
-        if which(launcher) is None:
-            self.log.raiseException("Specified launcher '%s' not found in $PATH" % launcher)
+        if launcher == RM_HYDRA_LAUNCHER:
+            launcher = self.RM_HYDRA_LAUNCHER
 
         if not self.is_local():
             self.mpiexec_options.append("-%s %s" % (self.HYDRA_LAUNCHER_NAME, launcher))

--- a/lib/vsc/mympirun/mpi/mpich.py
+++ b/lib/vsc/mympirun/mpi/mpich.py
@@ -88,7 +88,7 @@ class MVAPICH2(MVAPICH2Hydra):
     def make_mpdboot_options(self):
         """Small fix"""
 
-        self.mpdboot_options.append("--totalnum=%s" % len(nub(self.nodes)))
+        self.mpdboot_options.append("--totalnum=%s" % len(self.nodes_uniq))
 
         super(MVAPICH2, self).make_mpdboot_options()
 

--- a/lib/vsc/mympirun/mpi/mpich.py
+++ b/lib/vsc/mympirun/mpi/mpich.py
@@ -31,7 +31,7 @@ import os
 
 from vsc.mympirun.mpi.mpi import MPI, version_in_range
 from vsc.utils.run import run_simple
-from vsc.utils.missing import nub
+
 
 class MVAPICH2Hydra(MPI):
 

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -96,7 +96,7 @@ class OpenMPI(MPI):
 
         ranktxt = ""
         sockets_per_node = self.determine_sockets_per_node()
-        universe = self.options.universe or len(self.nodes)
+        universe = self.options.universe or self.nodes_tot_cnt
 
         try:
             rankfn = os.path.join(self.mympirundir, 'rankfile')
@@ -112,7 +112,7 @@ class OpenMPI(MPI):
             elif override_type in ('spread', 'scatter'):
                 #spread ranks evenly across nodes, but also spread them across sockets
                 for rank in range(universe):
-                    node = rank % len(self.nodes)
+                    node = rank % self.nodes_tot_cnt
                     socket = (rank % self.ppn) % sockets_per_node
                     slot = (rank % self.ppn) / sockets_per_node
                     ranktxt += "rank %i=+n%i slot=%i:%i\n" %(rank, node, socket, slot)

--- a/lib/vsc/mympirun/rm/local.py
+++ b/lib/vsc/mympirun/rm/local.py
@@ -50,6 +50,7 @@ class Local(Sched):
         localhostname = getattr(self, 'MPIRUN_LOCALHOSTNAME', 'localhost')
         self.nodes_tot_cnt = len(self.cpus)
         self.nodes_uniq = [localhostname]
+        self.nodes = self.nodes_uniq * self.nodes_tot_cnt
 
         self.log.debug("set_nodes: cnt: %d; uniq: %s", self.nodes_tot_cnt, self.nodes_uniq)
 

--- a/lib/vsc/mympirun/rm/local.py
+++ b/lib/vsc/mympirun/rm/local.py
@@ -36,7 +36,7 @@ class Local(Sched):
     """
     _sched_for = ['local']
     SCHED_ENVIRON_ID = None
-    SCHED_ENVIRON_NODEFILE = None
+    SCHED_ENVIRON_NODE_INFO = None
     AUTOGENERATE_JOBID = True
 
     HYDRA_LAUNCHER = 'local'
@@ -48,9 +48,10 @@ class Local(Sched):
         """
 
         localhostname = getattr(self, 'MPIRUN_LOCALHOSTNAME', 'localhost')
-        self.nodes = [localhostname] * len(self.cpus)
+        self.nodes_tot_cnt = len(self.cpus)
+        self.nodes_uniq = [localhostname]
 
-        self.log.debug("set_nodes: %s", self.nodes)
+        self.log.debug("set_nodes: cnt: %d; uniq: %s", self.nodes_tot_cnt, self.nodes_uniq)
 
     def is_local(self):
         """

--- a/lib/vsc/mympirun/rm/pbs.py
+++ b/lib/vsc/mympirun/rm/pbs.py
@@ -73,7 +73,7 @@ class PBS(Sched):
 
         try:
             self.nodes = [x.strip() for x in open(filename).read().split("\n") if len(x.strip()) > 0]
-            self.log.debug("set_nodes: from %s: %s", filename, nodes)
+            self.log.debug("set_nodes: from %s: %s", filename, self.nodes)
         except IOError:
             self.log.raiseException("set_nodes: failed to get nodes from nodefile %s" % filename)
 

--- a/lib/vsc/mympirun/rm/pbs.py
+++ b/lib/vsc/mympirun/rm/pbs.py
@@ -45,6 +45,7 @@ class PBS(Sched):
     SCHED_ENVIRON_NODE_INFO = 'PBS_NODEFILE'
 
     HYDRA_RMK = ['pbs']
+    RM_HYDRA_LAUNCHER = 'pbsdsh'
 
     def __init__(self, *args, **kwargs):
         """PBS constructor"""

--- a/lib/vsc/mympirun/rm/sched.py
+++ b/lib/vsc/mympirun/rm/sched.py
@@ -32,9 +32,11 @@ import re
 
 from vsc.utils.affinity import sched_getaffinity
 from vsc.utils.fancylogger import getLogger
-from vsc.utils.missing import get_subclasses, nub
+from vsc.utils.missing import get_subclasses
+
 
 LOGGER = getLogger()
+
 
 def what_sched(requested):
     """Return the scheduler class """

--- a/lib/vsc/mympirun/rm/sched.py
+++ b/lib/vsc/mympirun/rm/sched.py
@@ -54,7 +54,7 @@ def what_sched(requested):
 
     # next, try to use the scheduler defined by environment variables
     for sched in found_sched:
-        if sched.SCHED_ENVIRON_NODEFILE in os.environ and sched.SCHED_ENVIRON_ID in os.environ:
+        if sched.SCHED_ENVIRON_NODE_INFO in os.environ and sched.SCHED_ENVIRON_ID in os.environ:
             return sched, found_sched
 
     # If that fails, try to force the local scheduler
@@ -78,7 +78,7 @@ class Sched(object):
     _sched_for = []  # classname is default added
     _sched_environ_test = []
     SCHED_ENVIRON_ID = None
-    SCHED_ENVIRON_NODEFILE = None
+    SCHED_ENVIRON_NODE_INFO = None
 
     # if the SCHED_ENVIRON_ID is not found, create one yourself
     AUTOGENERATE_JOBID = False
@@ -111,7 +111,7 @@ class Sched(object):
         self.cpus = []
         self.set_cpus()
 
-        self.nodes = None
+        self.nodes, self.nodes_uniq, self.nodes_tot_cnt = None, None, None
         self.set_nodes()
 
         self.multiplier = None
@@ -235,7 +235,7 @@ class Sched(object):
     def is_large(self):
         """Determine if this is a large job or not"""
 
-        res = ((len(self.nodes) > self.RSH_LARGE_LIMIT) and
+        res = ((self.nodes_tot_cnt > self.RSH_LARGE_LIMIT) and
                (any(c == self.cores_per_node for c in self.ppn_dict.values())))
         self.log.debug("is_large returns %s", res)
         return res
@@ -261,7 +261,7 @@ class Sched(object):
         if self.options.hybrid is None:
             res = self.nodes * self.multiplier
         else:
-            for uniquenode in nub(self.nodes):
+            for uniquenode in self.nodes_uniq:
                 res.extend([uniquenode] * self.options.hybrid * self.multiplier)
 
         # reorder

--- a/lib/vsc/mympirun/rm/sched.py
+++ b/lib/vsc/mympirun/rm/sched.py
@@ -95,6 +95,7 @@ class Sched(object):
     HYDRA_RMK = []
     HYDRA_LAUNCHER = 'ssh'
     HYDRA_LAUNCHER_EXEC = None
+    RM_HYDRA_LAUNCHER = None
 
     def __init__(self, options=None, **kwargs):
         if not hasattr(self, 'log'):

--- a/lib/vsc/mympirun/rm/slurm.py
+++ b/lib/vsc/mympirun/rm/slurm.py
@@ -93,15 +93,15 @@ class SLURM(Sched):
         """Set list of nodes available in current environment."""
 
         self.nodes_uniq = self._get_uniq_nodes()
-        tasks_per_node = self._get_tasks_per_node()
+        tpn = self._get_tasks_per_node()
 
-        if len(self.nodes_uniq) != len(tasks_per_node):
-            self.log.raiseException("nodes_uniq vs tasks_per_node mismatch: %s vs %s" % (self.nodes_uniq, tasks_per_node))
+        if len(self.nodes_uniq) != len(tpn):
+            self.log.raiseException("nodes_uniq vs tpn (tasks per node) mismatch: %s vs %s" % (self.nodes_uniq, tpn))
 
-        self.nodes_tot_cnt = sum(tasks_per_node)
+        self.nodes_tot_cnt = sum(tpn)
 
         self.nodes = []
-        for (node, task_cnt) in zip(self.nodes_uniq, tasks_per_node):
+        for (node, task_cnt) in zip(self.nodes_uniq, tpn):
             self.nodes.extend([node] * task_cnt)
 
         self.log.debug("set_nodes: %s (cnt: %d; uniq: %s)", self.nodes, self.nodes_tot_cnt, self.nodes_uniq)

--- a/lib/vsc/mympirun/rm/slurm.py
+++ b/lib/vsc/mympirun/rm/slurm.py
@@ -57,7 +57,7 @@ class SLURM(Sched):
         cmd = "scontrol show hostname %s" % nodelist
         ec, out = run_simple(cmd)
         if ec:
-            self.raiseException("set_nodes: failed to get full list of unique hostnames using '%s': %s" % (cmd, out))
+            self.log.raiseException("set_nodes: failed to get list of unique hostnames using '%s': %s" % (cmd, out))
         else:
             res = out.strip().split('\n')
 
@@ -96,7 +96,7 @@ class SLURM(Sched):
         tasks_per_node = self._get_tasks_per_node()
 
         if len(self.nodes_uniq) != len(tasks_per_node):
-            self.raiseException("nodes_uniq vs tasks_per_node mismatch: %s vs %s" % (self.nodes_uniq, tasks_per_node))
+            self.log.raiseException("nodes_uniq vs tasks_per_node mismatch: %s vs %s" % (self.nodes_uniq, tasks_per_node))
 
         self.nodes_tot_cnt = sum(tasks_per_node)
 

--- a/lib/vsc/mympirun/rm/slurm.py
+++ b/lib/vsc/mympirun/rm/slurm.py
@@ -1,0 +1,91 @@
+#
+# Copyright 2018-2018 Ghent University
+#
+# This file is part of vsc-mympirun,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# the Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/hpcugent/vsc-mympirun
+#
+# vsc-mympirun is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# vsc-mympirun is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with vsc-mympirun.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+SLURM
+"""
+import os
+import re
+
+from vsc.mympirun.mpi.mpi import which
+from vsc.mympirun.rm.sched import Sched
+from vsc.utils.run import run_simple
+
+
+class SLURM(Sched):
+    """SLURM"""
+
+    _sched_for = ['slurm']
+    # these environment variables are used to detect we're running in a SLURM job environment (see what_sched function)
+    SCHED_ENVIRON_ID = 'SLURM_JOBID'
+    SCHED_ENVIRON_NODE_INFO = 'SLURM_NODELIST'
+
+    HYDRA_RMK = ['slurm']
+
+    def set_nodes(self):
+        """Set list of nodes available in current environment."""
+
+        # based on https://github.com/SchedMD/slurm/blob/master/contribs/torque/generate_pbs_nodefile.pl
+
+        # determine list of hostnames involved in job via "scontrol show hostname $SLURM_NODELIST"
+        nodelist = os.environ.get(self.SCHED_ENVIRON_NODE_INFO)
+        if nodelist is None:
+            self.log.raiseException("set_nodes: failed to get $%s from environment" % self.SCHED_ENVIRON_NODE_INFO)
+        else:
+            self.log.debug("set_nodes: obtained $%s value: %s", self.SCHED_ENVIRON_NODE_INFO, nodelist)
+
+        cmd = "scontrol show hostname %s" % nodelist
+        ec, out = run_simple(cmd)
+        if ec:
+            self.raiseException("set_nodes: failed to get full list of unique hostnames using '%s': %s" % (cmd, out))
+        else:
+            self.nodes_uniq = out.strip().split('\n')
+
+        tpn_key = 'SLURM_TASKS_PER_NODE'
+        tpn_spec = os.environ.get(tpn_key)
+        if tpn_spec is None:
+            self.log.raiseException("set_nodes: failed to get $%s from environment" % tpn_key)
+        else:
+            self.log.debug("set_nodes: obtained $%s value: %s", tpn_key, tpn_spec)
+            tasks_per_node = []
+            # duplicate counts are compacted into something like '2(x3)', so we unroll those
+            compact_regex = re.compile(r'^(?P<task_cnt>\d+)\(x(?P<repeat_cnt>\d+)\)$')
+            for entry in tpn_spec.split(','):
+                res = compact_regex.match(entry)
+                if res:
+                    tasks_per_node.extend([int(res.group('task_cnt'))] * int(res.group('repeat_cnt')))
+                else:
+                    tasks_per_node.append(int(entry))
+            self.log.debug("set_nodes: tasks_per_node: %s" % tasks_per_node)
+
+        if len(self.nodes_uniq) != len(tasks_per_node):
+            self.raiseException("nodes_uniq vs tasks_per_node mismatch: %s vs %s" % (self.nodes_uniq, tasks_per_node))
+
+        self.nodes_tot_cnt = sum(tasks_per_node)
+
+        self.nodes = []
+        for (node, task_cnt) in zip(self.nodes_uniq, tasks_per_node):
+            self.nodes.extend([node] * task_cnt)
+
+        self.log.debug("set_nodes: %s (cnt: %d; uniq: %s)", self.nodes, self.nodes_tot_cnt, self.nodes_uniq)

--- a/lib/vsc/mympirun/rm/slurm.py
+++ b/lib/vsc/mympirun/rm/slurm.py
@@ -42,6 +42,7 @@ class SLURM(Sched):
     SCHED_ENVIRON_NODE_INFO = 'SLURM_NODELIST'
 
     HYDRA_RMK = ['slurm']
+    RM_HYDRA_LAUNCHER = 'slurm'
 
     def set_nodes(self):
         """Set list of nodes available in current environment."""

--- a/lib/vsc/mympirun/rm/slurm.py
+++ b/lib/vsc/mympirun/rm/slurm.py
@@ -68,7 +68,7 @@ class SLURM(Sched):
         """Get $SLURM_TASKS_PER_NODE from environment and parse it into a list with task count per node."""
 
         # based on https://github.com/SchedMD/slurm/blob/master/contribs/torque/generate_pbs_nodefile.pl
-        res = None
+        tpn = None
 
         tpn_key = 'SLURM_TASKS_PER_NODE'
         tpn_spec = os.environ.get(tpn_key)
@@ -78,16 +78,16 @@ class SLURM(Sched):
             self.log.debug("set_nodes: obtained $%s value: %s", tpn_key, tpn_spec)
             # duplicate counts are compacted into something like '2(x3)', so we unroll those
             compact_regex = re.compile(r'^(?P<task_cnt>\d+)\(x(?P<repeat_cnt>\d+)\)$')
-            res = []
+            tpn = []
             for entry in tpn_spec.split(','):
                 res = compact_regex.match(entry)
                 if res:
-                    res.extend([int(res.group('task_cnt'))] * int(res.group('repeat_cnt')))
+                    tpn.extend([int(res.group('task_cnt'))] * int(res.group('repeat_cnt')))
                 else:
-                    res.append(int(entry))
+                    tpn.append(int(entry))
 
-        self.log.debug("_get_tasks_per_node: %s" % res)
-        return res
+        self.log.debug("_get_tasks_per_node: %s" % tpn)
+        return tpn
 
     def set_nodes(self):
         """Set list of nodes available in current environment."""

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ import os
 import pkgutil
 import sys
 import vsc.install.shared_setup as shared_setup
-from vsc.install.shared_setup import vsc_setup, log, sdw
+from vsc.install.shared_setup import vsc_setup, log, sdw, kh
 
 FAKE_SUBDIRECTORY_NAME = 'fake'
 
@@ -47,9 +47,9 @@ PACKAGE = {
         'vsc-install >= 0.10.25', # for modified subclassing
         'IPy',
     ],
-    'version': '4.0.4',
-    'author': [sdw],
-    'maintainer': [sdw],
+    'version': '4.1.0',
+    'author': [sdw, kh],
+    'maintainer': [sdw, kh],
     'zip_safe': False,
 }
 

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -114,7 +114,9 @@ class TestEnd2End(unittest.TestCase):
 
         # set variables that exist within jobs, but not locally, for testing
         self.tmpdir = tempfile.mkdtemp()
-        set_PBS_env(self.tmpdir)
+        pbs_tmpdir = os.path.join(self.tmpdir, 'pbs')
+        os.makedirs(pbs_tmpdir)
+        set_PBS_env(pbs_tmpdir)
 
     def tearDown(self):
         """Clean up after running test."""

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -111,12 +111,17 @@ class TestEnd2End(unittest.TestCase):
         ec, out = run_simple("%s -c 'import vsc.mympirun; print vsc.mympirun.__file__'" % sys.executable)
         expected_path = os.path.join(self.topdir, 'lib', 'vsc', 'mympirun')
         self.assertTrue(os.path.samefile(os.path.dirname(out.strip()), expected_path))
+
         # set variables that exist within jobs, but not locally, for testing
-        set_PBS_env()
+        self.tmpdir = tempfile.mkdtemp()
+        set_PBS_env(self.tmpdir)
 
     def tearDown(self):
         """Clean up after running test."""
-        cleanup_PBS_env(self.orig_environ)
+        cleanup_PBS_env()
+        os.chmod(self.tmpdir, stat.S_IRUSR|stat.S_IWUSR|stat.S_IXUSR)
+        shutil.rmtree(self.tmpdir)
+        os.environ = self.orig_environ
 
     def test_serial(self):
         """Test running of a serial command via mympirun."""
@@ -302,9 +307,6 @@ class TestEnd2End(unittest.TestCase):
         ncpus_regex = re.compile('--ncpus=1')
         self.assertTrue(np_regex.search(out), "Pattern %s found in %s" % (np_regex, out))
         self.assertFalse(ncpus_regex.search(out), "Pattern %s found in %s" % (ncpus_regex, out))
-
-        # re-set pbs environment
-        set_PBS_env()
 
     def test_env_variables(self):
         """ Test the passing of (extra) variables """

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -351,6 +351,8 @@ class TestMPI(TestCase):
             'node2',
             'node2',
         ]
+        inst.nodes_tot_cnt = len(inst.nodes)
+        inst.nodes_uniq = nub(inst.nodes)
         options = {
             2: {'node1': 1, 'node2': 1},
             3: {'node1': 2, 'node2': 1},
@@ -367,6 +369,8 @@ class TestMPI(TestCase):
         """ Test mpinode scheduling for --hybrid option """
         inst = getinstance(mpim.MPI, Local, MympirunOption())
         inst.nodes = ['node1']*4 + ['node2']*4
+        inst.nodes_tot_cnt = len(inst.nodes)
+        inst.nodes_uniq = nub(inst.nodes)
         options = range(1,9)
         for opt in options:
             inst.options.hybrid = opt

--- a/test/sched.py
+++ b/test/sched.py
@@ -91,7 +91,7 @@ def set_SLURM_env(tmpdir):
 
     scontrol = os.path.join(tmpdir, 'scontrol')
     fh = open(scontrol, 'w')
-    fh.write("!#/bin/bash\necho node1\necho node2\necho node3\n")
+    fh.write("#!/bin/bash\necho node1\necho node2\necho node3\n")
     fh.close()
 
     os.chmod(scontrol, stat.S_IRUSR|stat.S_IXUSR)
@@ -190,10 +190,12 @@ class TestSched(unittest.TestCase):
         nodes = ['node1', 'node1', 'node2', 'node3']
 
         for key in ['pbs', 'slurm']:
+            tmpdir = os.path.join(self.tmpdir, key)
+            os.makedirs(tmpdir)
             if key == 'pbs':
-                set_PBS_env(self.tmpdir, nodes=nodes)
+                set_PBS_env(tmpdir, nodes=nodes)
             elif key == 'slurm':
-                set_SLURM_env(self.tmpdir)
+                set_SLURM_env(tmpdir)
 
             pbs_class = SCHEDDICT[key]
 

--- a/test/sched.py
+++ b/test/sched.py
@@ -42,16 +42,19 @@ import vsc.mympirun.rm.sched as schedm
 from vsc.mympirun.rm.local import Local
 from vsc.mympirun.rm.pbs import PBS
 from vsc.mympirun.rm.scoop import Scoop
+from vsc.mympirun.rm.slurm import SLURM
 from vsc.utils import fancylogger
 
 SCHEDDICT = {
-    "local": Local,
-    "pbs": PBS, #doesn't work locally
-    "scoop": Scoop,
-    }
+    'local': Local,
+    'pbs': PBS,
+    'scoop': Scoop,
+    'slurm': SLURM,
+}
 
-os.environ['PBS_JOBID'] = "1"
-os.environ['PBS_NUM_PPN'] = "1"
+os.environ['PBS_JOBID'] = '1'
+os.environ['SLURM_JOBID'] = '1'
+os.environ['PBS_NUM_PPN'] = '1'
 
 def set_PBS_env():
     """ Set up the environment to recreate being in a hpc job """
@@ -85,7 +88,6 @@ class TestSched(unittest.TestCase):
 
     def setUp(self):
         self.orig_environ = os.environ
-        set_PBS_env()
 
     def tearDown(self):
         """Clean up after running test."""
@@ -140,7 +142,7 @@ class TestSched(unittest.TestCase):
         self.assertEqual(set(inst.nodes), set(['localhost']))
         self.assertEqual(len(inst.cpus), len(inst.nodes))
 
-    def test_set_node_list(self):
+    def test_set_node_list_pbs(self):
         """
         test different scenarios for setting node list
         """
@@ -150,6 +152,8 @@ class TestSched(unittest.TestCase):
             'node2',
             'node3',
         ]
+
+        set_PBS_env()
         pbs_class = SCHEDDICT['pbs']
         text = '\n'.join(nodes)
         os.chmod(os.environ['PBS_NODEFILE'], stat.S_IRUSR | stat.S_IWUSR)

--- a/test/sched.py
+++ b/test/sched.py
@@ -75,7 +75,7 @@ def set_PBS_env(nodes=None):
 def cleanup_PBS_env():
     """Clean up $PBS_NODEFILE in mocked PBS environment."""
     pbs_nodefile = os.environ.get('PBS_NODEFILE')
-    if pbs_nodefile:
+    if pbs_nodefile and os.path.exists(pbs_nodefile):
         os.chmod(pbs_nodefile, stat.S_IWUSR)
         os.chmod(os.path.dirname(pbs_nodefile), stat.S_IWUSR|stat.S_IRUSR|stat.S_IXUSR)
         shutil.rmtree(os.path.dirname(pbs_nodefile))


### PR DESCRIPTION
I want to clean up the new code in `rm/slurm.py` a bit so I can unit test it cleanly, especially the bit that parses `$SLURM_TASKS_PER_NODE`, hence `WIP`.