### PR TITLE
[bug fix] use CmdList to construct mpirun command

### DIFF
--- a/lib/vsc/mympirun/mpi/intelmpi.py
+++ b/lib/vsc/mympirun/mpi/intelmpi.py
@@ -32,6 +32,7 @@ import os
 import socket
 import tempfile
 from vsc.utils.missing import nub
+from vsc.utils.run import CmdList
 
 from vsc.mympirun.mpi.mpi import MPI, RM_HYDRA_LAUNCHER, version_in_range, which
 
@@ -72,7 +73,7 @@ class IntelMPI(MPI):
 
     OPTS_FROM_ENV_FLAVOR_PREFIX = ['I_MPI']
 
-    OPTS_FROM_ENV_TEMPLATE = "-envlist %(commaseparated)s"
+    OPTS_FROM_ENV_TEMPLATE = ['-envlist', '%(commaseparated)s']
 
     def _has_hydra(self):
         """Has HYDRA or not"""
@@ -168,11 +169,11 @@ class IntelMPI(MPI):
 
         self.log.debug("pinning_override: type %s ", self.pinning_override_type)
 
-        cmd = ""
+        cmd = CmdList()
         if self.pinning_override_type in ('packed', 'compact', 'bunch'):
-            cmd = "-env I_MPI_PIN_PROCESSOR_LIST=allcores:map=bunch"
+            cmd.add(['-env', 'I_MPI_PIN_PROCESSOR_LIST=allcores:map=bunch'])
         elif self.pinning_override_type in ('spread', 'scatter'):
-            cmd = "-env I_MPI_PIN_PROCESSOR_LIST=allcores"
+            cmd.add(['-env', 'I_MPI_PIN_PROCESSOR_LIST=allcores'])
         else:
             self.log.raiseException("pinning_override: unsupported pinning_override_type  %s" %
                                     self.pinning_override_type)

--- a/lib/vsc/mympirun/mpi/mpich.py
+++ b/lib/vsc/mympirun/mpi/mpich.py
@@ -45,7 +45,7 @@ class MVAPICH2Hydra(MPI):
 
     OPTS_FROM_ENV_FLAVOR_PREFIX = ['MV2', 'HYDRA']
 
-    OPTS_FROM_ENV_TEMPLATE = "-envlist %(commaseparated)s"
+    OPTS_FROM_ENV_TEMPLATE = ['-envlist', '%(commaseparated)s']
 
     def prepare(self):
         super(MVAPICH2Hydra, self).prepare()
@@ -68,7 +68,7 @@ class MVAPICH2Hydra(MPI):
         Create the acual mpirun command
         MVAPICH2Hydra doesn't need mpdboot options
         """
-        self.mpirun_cmd += self.mpiexec_options
+        self.mpirun_cmd.add(self.mpiexec_options)
 
 
 class MVAPICH2(MVAPICH2Hydra):
@@ -88,7 +88,7 @@ class MVAPICH2(MVAPICH2Hydra):
     def make_mpdboot_options(self):
         """Small fix"""
 
-        self.mpdboot_options.append("--totalnum=%s" % len(self.nodes_uniq))
+        self.mpdboot_options.add("--totalnum=%s" % len(self.nodes_uniq))
 
         super(MVAPICH2, self).make_mpdboot_options()
 
@@ -122,7 +122,7 @@ class MPICH2Hydra(MVAPICH2Hydra):
         # add pinning
         options = super(MPICH2Hydra, self).get_mpiexec_global_options()
         if self.options.pinmpi:
-            options.extend(['-binding', 'rr', '-topolib', 'hwloc'])
+            options.add(['-binding', 'rr', '-topolib', 'hwloc'])
         return options
 
 
@@ -140,5 +140,5 @@ class MPICH2(MVAPICH2):
         # add pinning
         options = super(MPICH2, self).get_mpiexec_global_options()
         if self.options.pinmpi:
-            options.extend(['-binding', 'rr', '-topolib', 'hwloc'])
+            options.add(['-binding', 'rr', '-topolib', 'hwloc'])
         return options

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ PACKAGE = {
         'vsc-install >= 0.10.25',  # for modified subclassing
         'IPy',
     ],
-    'version': '4.1.3',
+    'version': '4.1.4',
     'author': [sdw, kh],
     'maintainer': [sdw, kh],
     'zip_safe': False,

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ MYMPIRUN_ALIASES = ['ihmpirun', 'impirun', 'm2hmpirun', 'm2mpirun', 'mhmpirun', 
 
 PACKAGE = {
     'install_requires': [
-        'vsc-base >= 2.7.4',
+        'vsc-base >= 2.8.0',  # for CmdList
         'vsc-install >= 0.10.25',  # for modified subclassing
         'IPy',
     ],


### PR DESCRIPTION
`mympirun` is utterly broken since v4.1.2 thanks to the naive switch to `run` in #144 , because the `mpirun` command isn't being constructed carefully enough.

This leads to errors like:

```
[mpiexec@node2128.delcatty.os] match_arg (../../utils/args/args.c:254): unrecognized argument machinefile /user/home/gent/vsc400/vsc40023/.mympirun_bfxlm3/4473084.master15.delcatty.gent.vsc_20180606_151207/nodes
[mpiexec@node2128.delcatty.os] HYDU_parse_array (../../utils/args/args.c:269): argument matching returned error
[mpiexec@node2128.delcatty.os] parse_args (../../ui/mpich/utils.c:4770): error parsing input array
[mpiexec@node2128.delcatty.os] HYD_uii_mpx_get_parameters (../../ui/mpich/utils.c:5106): unable to parse user arguments

Usage: ./mpiexec [global opts] [exec1 local opts] : [exec2 local opts] : ...
```

Each argument/option *must* be a separate item in the `self.mpirun_cmd` list.

The `CmdList` class added to `vsc-base` in https://github.com/hpcugent/vsc-base/pull/270 that wraps around `list` is a useful way to avoid these problems.

Tested with:

* full-cluster GROMACS on `delcatty` & `skitty`
* ...