### PR TITLE
don't use quotes around values in templates for --mca and -genv since they're passed literally to the mpirun command

### DIFF
--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -285,7 +285,7 @@ class MPI(object):
     MPDBOOT_OPTIONS = []
     MPDBOOT_SET_INTERFACE = True
 
-    MPIEXEC_TEMPLATE_GLOBAL_OPTION = ['-genv', '%(name)s', "'%(value)s'"]
+    MPIEXEC_TEMPLATE_GLOBAL_OPTION = ['-genv', '%(name)s', "%(value)s"]
     OPTS_FROM_ENV_TEMPLATE = ['-x', '%(name)s']
     MPIEXEC_OPTIONS = []
 

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -48,7 +48,7 @@ class OpenMPI(MPI):
 
     DEVICE_MPIDEVICE_MAP = {'ib': 'sm,openib,self', 'det': 'sm,tcp,self', 'shm': 'sm,self', 'socket': 'sm,tcp,self'}
 
-    MPIEXEC_TEMPLATE_GLOBAL_OPTION = ['--mca', '%(name)s', "'%(value)s'"]
+    MPIEXEC_TEMPLATE_GLOBAL_OPTION = ['--mca', '%(name)s', "%(value)s"]
 
     REMOTE_OPTION_TEMPLATE = ['--mca', 'pls_rsh_agent', '%(rsh)s']
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ PACKAGE = {
         'vsc-install >= 0.10.25',  # for modified subclassing
         'IPy',
     ],
-    'version': '4.1.4',
+    'version': '4.1.5',
     'author': [sdw, kh],
     'maintainer': [sdw, kh],
     'zip_safe': False,

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -140,8 +140,8 @@ class TestEnd2End(unittest.TestCase):
         install_fake_mpirun('mpirun', self.tmpdir, 'impi', '5.1.2')
         regex_tmpl = "^fake mpirun called with args: .*%s.* hostname$"
         testcases = {
-            'impirun': "-genv I_MPI_DEVICE 'shm'",
-            'ompirun': "--mca btl 'sm,.*self'",
+            'impirun': "-genv I_MPI_DEVICE shm",
+            'ompirun': "--mca btl sm,.*self",
         }
         for key in testcases:
             ec, out = run([sys.executable, self.mympiscript, '--setmpi', key, '--sched', 'local', 'hostname'])
@@ -442,8 +442,8 @@ class TestEnd2End(unittest.TestCase):
         self.assertEqual(ec, 0, "Command exited normally: exit code %s; output: %s" % (ec, out))
 
         # make sure output includes defined environment variables
-        # and "--mca orte_keep_fqdn_hostnames '1'"
-        mca_keep_fqdn = "^fake mpirun called with args:.*--mca orte_keep_fqdn_hostnames '1'.*hostname$"
+        # and "--mca orte_keep_fqdn_hostnames 1"
+        mca_keep_fqdn = "^fake mpirun called with args:.*--mca orte_keep_fqdn_hostnames 1 .*hostname$"
         for pattern in ['^HOME=', '^USER=', '^SLURM_JOBID=', mca_keep_fqdn]:
             regex = re.compile(pattern, re.M)
             self.assertTrue(regex.search(out), "Pattern '%s' found in: %s" % (regex.pattern, out))


### PR DESCRIPTION
Another side-effect of the switch to `run` in #144, which was not dealt with in #145

fix for problems that occurs when using `mympirun` on top of OpenMPI:

```
An invalid value was supplied for an enum variable.

  Variable     : orte_keep_fqdn_hostnames
  Value        : '1'
  Valid values : 0: f|false|disabled|no, 1: t|true|enabled|yes
```