### PR TITLE
use 'vader' rather than 'sm' for OpenMPI 3.0 & newer

### DIFF
--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -101,7 +101,7 @@ def what_mpi(name):
     # check if mympirun was called by a known mpirun alias (like
     # ompirun for OpenMPI or mhmpirun for mpich)
     for mpi in supp_mpi_impl:
-        if mpi._is_mpiscriptname_for(scriptname):
+        if mpi._is_mpiscriptname_for(scriptname) and mpi._is_mpirun_for(mpirun_path):
             LOGGER.debug("%s was used to call mympirun", scriptname)
             return scriptname, mpi, supp_mpi_impl
 

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -46,7 +46,12 @@ class OpenMPI(MPI):
     _mpirun_for = 'OpenMPI'
     _mpirun_version = staticmethod(lambda ver: version_in_range(ver, None, '1.7.0'))
 
-    DEVICE_MPIDEVICE_MAP = {'ib': 'sm,openib,self', 'det': 'sm,tcp,self', 'shm': 'sm,self', 'socket': 'sm,tcp,self'}
+    DEVICE_MPIDEVICE_MAP = {
+        'det': 'sm,tcp,self',
+        'ib': 'sm,openib,self',
+        'shm': 'sm,self',
+        'socket': 'sm,tcp,self',
+    }
 
     MPIEXEC_TEMPLATE_GLOBAL_OPTION = ['--mca', '%(name)s', "%(value)s"]
 
@@ -186,7 +191,7 @@ class OpenMpiOversubscribe(OpenMPI):
     when requesting more processes than available processors.
     """
 
-    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '1.7.0', None))
+    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '1.7.0', '3.0.0'))
 
 
     def set_mpiexec_options(self):
@@ -195,3 +200,21 @@ class OpenMpiOversubscribe(OpenMPI):
 
         if self.multiplier > 1 or len(self.mpinodes) > self.ppn:
             self.mpiexec_options.add("--oversubscribe")
+
+
+class OpenMpi3(OpenMpiOversubscribe):
+
+    """
+    An implementation of the MPI class for OpenMPI 3.x & more recent.
+    """
+
+    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '3.0.0', None))
+
+    # 'sm' BTL (Byte Transfer Layer) was replaced by the 'vader' BTL
+    # cfr. https://www.open-mpi.org/faq/?category=sm
+    DEVICE_MPIDEVICE_MAP = {
+        'det': 'vader,tcp,self',
+        'ib': 'vader,openib,self',
+        'shm': 'vader,self',
+        'socket': 'vader,tcp,self',
+    }

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -191,7 +191,7 @@ class OpenMpiOversubscribe(OpenMPI):
     when requesting more processes than available processors.
     """
 
-    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '1.7.0', '3.0.0'))
+    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '1.7.0', '3'))
 
 
     def set_mpiexec_options(self):
@@ -208,7 +208,7 @@ class OpenMpi3(OpenMpiOversubscribe):
     An implementation of the MPI class for OpenMPI 3.x & more recent.
     """
 
-    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '3.0.0', None))
+    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '3', None))
 
     # 'sm' BTL (Byte Transfer Layer) was replaced by the 'vader' BTL
     # cfr. https://www.open-mpi.org/faq/?category=sm

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ PACKAGE = {
         'vsc-install >= 0.10.25',  # for modified subclassing
         'IPy',
     ],
-    'version': '4.1.5',
+    'version': '4.1.6',
     'author': [sdw, kh],
     'maintainer': [sdw, kh],
     'zip_safe': False,

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -142,7 +142,8 @@ class TestEnd2End(unittest.TestCase):
 
         def run_test(mpi_name, mpi_ver, mpirun, pattern):
             """Utilitiy function to run test for a specific case."""
-            install_fake_mpirun('mpirun', self.tmpdir, mpi_name, mpi_ver)
+            tmpdir = os.path.join(self.tmpdir, '%s-%s' % (mpi_name, mpi_ver))
+            install_fake_mpirun('mpirun', tmpdir, mpi_name, mpi_ver)
 
             ec, out = run([sys.executable, self.mympiscript, '--setmpi', mpirun, '--sched', 'local', 'hostname'])
             self.assertEqual(ec, 0, "Command exited normally: exit code %s; output: %s" % (ec, out))

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -155,7 +155,7 @@ class TestEnd2End(unittest.TestCase):
         run_test('impi', '4.0.0', 'impirun', "-genv I_MPI_DEVICE shm")
         run_test('impi', '5.1.2', 'impirun', "-genv I_MPI_FABRICS shm")
         run_test('openmpi', '1.5', 'ompirun', "--mca btl sm,.*self")
-        run_test('openmpi', '2.0', 'ompirun', "--mca btl sm,.*self")
+        run_test('openmpi', '2.5', 'ompirun', "--mca btl sm,.*self")
         run_test('openmpi', '3.1', 'ompirun', "--mca btl vader,.*self")
 
     def test_output(self):

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -152,7 +152,8 @@ class TestEnd2End(unittest.TestCase):
             regex = re.compile(regex_tmpl % pattern)
             self.assertTrue(regex.match(out.strip()), "Pattern '%s' found in: %s" % (regex.pattern, out))
 
-        run_test('impi', '5.1.2', 'impirun', "-genv I_MPI_DEVICE shm")
+        run_test('impi', '4.0.0', 'impirun', "-genv I_MPI_DEVICE shm")
+        run_test('impi', '5.1.2', 'impirun', "-genv I_MPI_FABRICS shm")
         run_test('openmpi', '1.5', 'ompirun', "--mca btl sm,.*self")
         run_test('openmpi', '2.0', 'ompirun', "--mca btl sm,.*self")
         run_test('openmpi', '3.1', 'ompirun', "--mca btl vader,.*self")

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -136,19 +136,23 @@ class TestEnd2End(unittest.TestCase):
         self.assertTrue(regex.match(out.strip()), "Pattern '%s' found in: %s" % (regex.pattern, out))
 
     def test_sched(self):
-        """ Test --sched(type) option """
-        install_fake_mpirun('mpirun', self.tmpdir, 'impi', '5.1.2')
+        """Test --sched(type) option."""
+
         regex_tmpl = "^fake mpirun called with args: .*%s.* hostname$"
-        testcases = {
-            'impirun': "-genv I_MPI_DEVICE shm",
-            'ompirun': "--mca btl sm,.*self",
-        }
-        for key in testcases:
-            ec, out = run([sys.executable, self.mympiscript, '--setmpi', key, '--sched', 'local', 'hostname'])
+
+        def run_test(mpi_name, mpi_ver, mpirun, pattern):
+            """Utilitiy function to run test for a specific case."""
+            install_fake_mpirun('mpirun', self.tmpdir, mpi_name, mpi_ver)
+
+            ec, out = run([sys.executable, self.mympiscript, '--setmpi', mpirun, '--sched', 'local', 'hostname'])
             self.assertEqual(ec, 0, "Command exited normally: exit code %s; output: %s" % (ec, out))
-            regex = re.compile(regex_tmpl % testcases[key])
+            regex = re.compile(regex_tmpl % pattern)
             self.assertTrue(regex.match(out.strip()), "Pattern '%s' found in: %s" % (regex.pattern, out))
 
+        run_test('impi', '5.1.2', 'impirun', "-genv I_MPI_DEVICE shm")
+        run_test('openmpi', '1.5', 'ompirun', "--mca btl sm,.*self")
+        run_test('openmpi', '2.0', 'ompirun', "--mca btl sm,.*self")
+        run_test('openmpi', '3.1', 'ompirun', "--mca btl vader,.*self")
 
     def test_output(self):
         """ Test --output option """

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -71,6 +71,8 @@ fi
 
 def install_fake_mpirun(cmdname, path, mpi_name, mpi_version, txt=None):
     """Install fake mpirun command with given name in specified location"""
+    if not os.path.exists(path):
+        os.makedirs(path)
     fake_mpirun = os.path.join(path, cmdname)
     if not txt:
         txt = FAKE_MPIRUN


### PR DESCRIPTION
fix for #149