### PR TITLE
specify that long description is in MarkDown format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,11 @@ PACKAGE = {
         'vsc-install >= 0.10.25',  # for modified subclassing
         'IPy',
     ],
-    'version': '4.1.8',
+    'version': '4.1.9',
     'author': [sdw, kh],
     'maintainer': [sdw, kh],
     'zip_safe': False,
+    'long_description_content_type': 'text/markdown',
 }
 
 


### PR DESCRIPTION
Uploading latest version to PyPI failed with:

```
INFO: running upload
Upload failed (400): The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.
```

I hope this fixes that problem...