### PR TITLE
fix faulty log statement that is triggered when OpenMPI is used and is defined

### DIFF
--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -177,7 +177,7 @@ class OpenMPI(MPI):
         # (unless OpenMPI installation was configured with --enable-orterun-prefix-by-default)
         # cfr. https://www.mail-archive.com/devel@lists.open-mpi.org/msg17305.html
         if SLURM_EXPORT_ENV in os.environ:
-            self.log.info("Undefining $SLURM_EXPORT_ENV (was '%s')", SLURM_EXPORT_ENV, os.getenv(SLURM_EXPORT_ENV))
+            self.log.info("Undefining $%s (was '%s')", SLURM_EXPORT_ENV, os.getenv(SLURM_EXPORT_ENV))
             del os.environ[SLURM_EXPORT_ENV]
 
         super(OpenMPI, self).prepare()

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ PACKAGE = {
         'vsc-install >= 0.10.25',  # for modified subclassing
         'IPy',
     ],
-    'version': '4.1.8',
+    'version': '4.1.9',
     'author': [sdw, kh],
     'maintainer': [sdw, kh],
     'zip_safe': False,


### PR DESCRIPTION
fix for this traceback being printed (non-fatal)

```
Traceback (most recent call last):
  File "/apps/gent/CO7/skylake-ib/software/Python/2.7.15-foss-2018b/lib/python2.7/logging/__init__.py", line 868, in emit
    msg = self.format(record)
  File "/apps/gent/CO7/skylake-ib/software/Python/2.7.15-foss-2018b/lib/python2.7/logging/__init__.py", line 741, in format
    return fmt.format(record)
  File "/apps/gent/CO7/skylake-ib/software/Python/2.7.15-foss-2018b/lib/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/apps/gent/CO7/skylake-ib/software/Python/2.7.15-foss-2018b/lib/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Logged from file openmpi.py, line 180
```