### PR TITLE
use UCX as PML with OpenMPI 4.x and newer, if ompi_info reports it as supported

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,8 @@ node {
     }
     stage('test') {
         sh 'python2.7 -V'
-        sh 'pip3 install --ignore-installed --user tox'
-        sh 'export PATH=$HOME/.local/bin:$PATH && tox -v -c tox.ini'
+        sh 'pip3 install --ignore-installed --prefix $PWD/.vsc-tox tox'
+        sh 'export PATH=$PWD/.vsc-tox/bin:$PATH && export PYTHONPATH=$PWD/.vsc-tox/lib/python$(python3 -c "import sys; print(\\"%s.%s\\" % sys.version_info[:2])")/site-packages:$PYTHONPATH && tox -v -c tox.ini'
+        sh 'rm -r $PWD/.vsc-tox'
     }
 }

--- a/lib/vsc/mympirun/main.py
+++ b/lib/vsc/mympirun/main.py
@@ -121,4 +121,3 @@ def main(mpim, mpiopt, schedm):
     except Exception as err:
         fancylogger.getLogger().exception("Main failed: %s" % err)
         sys.exit(1)
-

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -154,11 +154,26 @@ class MPI(MpiBase):
     HYDRA = None
     HYDRA_LAUNCHER_NAME = "launcher"
 
-    DEVICE_LOCATION_MAP = {'ib': '/dev/infiniband', 'det': '/dev/det', 'shm': '/dev/shm', 'socket': None}
+    DEVICE_LOCATION_MAP = {
+        'ib': '/dev/infiniband',
+        'det': '/dev/det',
+        'shm': '/dev/shm',
+        'socket': None,
+    }
     DEVICE_ORDER = ['ib', 'det', 'shm', 'socket']
-    DEVICE_MPIDEVICE_MAP = {'ib': 'rdma', 'det': 'det', 'shm': 'shm', 'socket': 'socket'}
+    DEVICE_MPIDEVICE_MAP = {
+        'ib': 'rdma',
+        'det': 'det',
+        'shm': 'shm',
+        'socket': 'socket',
+    }
 
-    NETMASK_TYPE_MAP = {'ib': 'ib', 'det': 'eth', 'shm': 'eth', 'socket': 'eth'}
+    NETMASK_TYPE_MAP = {
+        'ib': 'ib',
+        'det': 'eth',
+        'shm': 'eth',
+        'socket': 'eth',
+    }
 
     PINNING_OVERRIDE_METHOD = 'numactl'
 

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -429,9 +429,8 @@ class MPI(MpiBase):
 
         mpdfn = os.path.join(self.mympirundir, 'mpdboot')
         try:
-            fp = open(mpdfn, 'w')
-            fp.write(mpdboottxt)
-            fp.close()
+            with open(mpdfn, 'w') as fp:
+                fp.write(mpdboottxt)
         except IOError as err:
             msg = 'make_mpdboot_file: failed to write mpbboot file %s: %s' % (mpdfn, err)
             self.log.raiseException(msg)
@@ -464,9 +463,8 @@ class MPI(MpiBase):
 
         nodefn = os.path.join(self.mympirundir, 'nodes')
         try:
-            fp = open(nodefn, 'w')
-            fp.write(nodetxt)
-            fp.close()
+            with open(nodefn, 'w') as fp:
+                fp.write(nodetxt)
         except IOError as err:
             msg = 'make_machine_file: failed to write nodefile %s: %s' % (nodefn, err)
             self.log.raiseException(msg)
@@ -561,10 +559,10 @@ class MPI(MpiBase):
         if not os.path.exists(mpdconffn):
             self.log.warning(("make_mpdboot: mpd.conf file not found at %s. Creating this file "
                               "(text file with minimal entry 'password=<somesecretpassword>')"), mpdconffn)
-            mpdconff = open(mpdconffn, 'w')
-            mpdconff.write("password=%s" % ''.join(random.choice(string.ascii_uppercase + string.digits)
-                                                   for x in range(10)))
-            mpdconff.close()
+
+            with open(mpdconffn, 'w') as mpdconff:
+                mpdconff.write("password=%s" % ''.join(random.choice(string.ascii_uppercase + string.digits)
+                                                       for x in range(10)))
             # set correct permissions on this file.
             os.chmod(mpdconffn, stat.S_IREAD)
 

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -232,7 +232,7 @@ class OpenMpi3(OpenMpiOversubscribe):
     }
 
 
-class OpenMpi4(OpenMpiOversubscribe):
+class OpenMpi4(OpenMpi3):
 
     """
     An implementation of the MPI class for OpenMPI 4.x & more recent.

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -243,7 +243,11 @@ class OpenMpi4(OpenMpiOversubscribe):
     def use_ucx_pml(self):
         """Determine whether or not to use the UCX Point-to-Point Messaging Layer (PML)."""
 
-        # if 'ompi_info' reports that UCX is a supported PML
+        # use UCX if 'ompi_info' reports that it is a supported PML;
+        # only for OpenMPI 4.x and newer, as recommended by UCX:
+        # "OpenMPI supports UCX starting from version 3.0, but it's recommended to use
+        # "version 4.0 or higher due to stability and performance improvements."
+        # (see https://openucx.github.io/ucx/running.html#openmpi-with-ucx)
         cmd = "ompi_info"
         ec, out = run(cmd)
         if ec:

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -30,7 +30,7 @@ import os
 import re
 import sys
 from vsc.utils.missing import nub
-from vsc.utils.run import CmdList
+from vsc.utils.run import CmdList, run
 
 from vsc.mympirun.common import version_in_range
 from vsc.mympirun.mpi.mpi import MPI
@@ -58,9 +58,21 @@ class OpenMPI(MPI):
 
     REMOTE_OPTION_TEMPLATE = ['--mca', 'pls_rsh_agent', '%(rsh)s']
 
+    def use_ucx_pml(self):
+        """Determine whether or not to use the UCX Point-to-Point Messaging Layer (PML)."""
+        # don't use UCX by default (mostly because of backwards-compatibility)
+        return False
+
     def set_mpiexec_global_options(self):
         """Set mpiexec global options"""
-        self.mpiexec_global_options['btl'] = self.device
+
+        if self.use_ucx_pml():
+            self.mpiexec_global_options['pml'] = 'ucx'
+            # disable uct btl, see http://openucx.github.io/ucx/running.html
+            self.mpiexec_global_options['btl'] = '^uct'
+        else:
+            # default PML (ob1) uses Byte Transport Layer (BTL)
+            self.mpiexec_global_options['btl'] = self.device
 
         # make sure Open Run-Time Environment (ORTE) uses FQDN hostnames
         # using short hostnames may cause problems (e.g. if SLURM is configured to use FQDN hostnames)
@@ -121,26 +133,27 @@ class OpenMPI(MPI):
                     node = rank / self.ppn
                     socket = rank / (self.ppn / sockets_per_node)
                     slot = rank % (self.ppn / sockets_per_node)
-                    ranktxt += "rank %i=+n%i slot=%i:%i\n" %(rank, node, socket, slot)
+                    ranktxt += "rank %i=+n%i slot=%i:%i\n" % (rank, node, socket, slot)
 
             elif override_type in ('spread', 'scatter'):
-                #spread ranks evenly across nodes, but also spread them across sockets
+                # spread ranks evenly across nodes, but also spread them across sockets
                 for rank in range(universe):
                     node = rank % self.nodes_tot_cnt
                     socket = (rank % self.ppn) % sockets_per_node
                     slot = (rank % self.ppn) / sockets_per_node
-                    ranktxt += "rank %i=+n%i slot=%i:%i\n" %(rank, node, socket, slot)
+                    ranktxt += "rank %i=+n%i slot=%i:%i\n" % (rank, node, socket, slot)
 
             else:
                 self.log.raiseException("pinning_override: unsupported pinning_override_type  %s" %
                                         self.pinning_override_type)
 
-            open(rankfn, 'w').write(ranktxt)
+            with open(rankfn, 'w') as fp:
+                fp.write(ranktxt)
             self.log.debug("pinning_override: wrote rankfile %s:\n%s", rankfn, ranktxt)
             cmd = CmdList('-rf', rankfn)
 
-        except IOError:
-            self.log.raiseException('pinning_override: failed to write rankfile %s' % rankfn)
+        except IOError as err:
+            self.log.raiseException('pinning_override: failed to write rankfile %s: %s' % (rankfn, err))
 
         return cmd
 
@@ -184,7 +197,6 @@ class OpenMPI(MPI):
         super(OpenMPI, self).prepare()
 
 
-
 class OpenMpiOversubscribe(OpenMPI):
 
     """
@@ -193,7 +205,6 @@ class OpenMpiOversubscribe(OpenMPI):
     """
 
     _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '1.7.0', '3'))
-
 
     def set_mpiexec_options(self):
 
@@ -209,7 +220,7 @@ class OpenMpi3(OpenMpiOversubscribe):
     An implementation of the MPI class for OpenMPI 3.x & more recent.
     """
 
-    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '3', None))
+    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '3', '4'))
 
     # 'sm' BTL (Byte Transfer Layer) was replaced by the 'vader' BTL
     # cfr. https://www.open-mpi.org/faq/?category=sm
@@ -219,3 +230,24 @@ class OpenMpi3(OpenMpiOversubscribe):
         'shm': 'vader,self',
         'socket': 'vader,tcp,self',
     }
+
+
+class OpenMpi4(OpenMpiOversubscribe):
+
+    """
+    An implementation of the MPI class for OpenMPI 4.x & more recent.
+    """
+
+    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '4', None))
+
+    def use_ucx_pml(self):
+        """Determine whether or not to use the UCX Point-to-Point Messaging Layer (PML)."""
+
+        # if 'ompi_info' reports that UCX is a supported PML
+        cmd = "ompi_info"
+        ec, out = run(cmd)
+        if ec:
+            self.log.raiseException("use_ucx_pml: failed to run cmd '%s', ec: %s, out: %s" % (cmd, ec, out))
+
+        pml_ucx_pattern = ' pml: ucx '
+        return bool(re.search(pml_ucx_pattern, out))

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ PACKAGE = {
     'tests_require': [
         'mock',
     ],
-    'version': '5.1.0',
+    'version': '5.2.0',
     'author': [sdw, kh],
     'maintainer': [sdw, kh],
     'zip_safe': False,

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -477,7 +477,7 @@ class TestEnd2End(TestCase):
 
         self.assertEqual(ec, 0, "Command exited normally: exit code %s; output: %s" % (ec, out))
 
-        regex = re.compile("^fake mpirun called with args:.*--mca btl vader,openib,self")
+        regex = re.compile("^fake mpirun called with args:.*--mca btl vader[a-z,]+self")
         self.assertTrue(regex.search(out), "Pattern '%s' should be found in: %s" % (regex.pattern, out))
 
     def test_openmpi4(self):
@@ -498,8 +498,8 @@ class TestEnd2End(TestCase):
         regex = re.compile(r"^fake mpirun called with args:.*--mca pml ucx --mca btl \^uct")
         self.assertTrue(regex.search(out), "Pattern '%s' should be found in: %s" % (regex.pattern, out))
 
-        # openib BTL should not be used when UCX is used as PML
-        regex = re.compile("--mca btl .*openib")
+        # BTL self should not be specified when UCX is used as PML (but 'btl ^uct' is specified)
+        regex = re.compile("--mca btl .*self")
         self.assertFalse(regex.search(out), "Pattern '%s' should not be found in: %s" % (regex.pattern, out))
 
         # if ompi_info doesn't report UCX as a supported PML, then openib btl is still used
@@ -509,5 +509,5 @@ class TestEnd2End(TestCase):
         ec, out = run([sys.executable, self.mympiscript, 'mpi_hello'])
         self.assertEqual(ec, 0, "Command exited normally: exit code %s; output: %s" % (ec, out))
 
-        regex = re.compile("^fake mpirun called with args:.*--mca btl vader,openib,self")
+        regex = re.compile("^fake mpirun called with args:.*--mca btl vader[a-z,]+self")
         self.assertTrue(regex.search(out), "Pattern '%s' should be found in: %s" % (regex.pattern, out))

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -29,18 +29,12 @@ End-to-end tests for mympirun (with mocking of real 'mpirun' command).
 @author: Kenneth Hoste (HPC-UGent)
 @author: Caroline De Brouwer (HPC-UGent)
 """
-import logging
-logging.basicConfig(level=logging.DEBUG)
-
 import copy
 import glob
 import os
 import re
-import shutil
 import stat
 import sys
-import tempfile
-import unittest
 import vsc.mympirun.rm.sched as schedm
 from vsc.install.testing import TestCase
 from vsc.utils.missing import nub
@@ -74,6 +68,7 @@ else
 fi
 """
 
+
 def install_fake_mpirun(cmdname, path, mpi_name, mpi_version, txt=None):
     """Install fake mpirun command with given name in specified location"""
     if not os.path.exists(path):
@@ -82,7 +77,7 @@ def install_fake_mpirun(cmdname, path, mpi_name, mpi_version, txt=None):
     if not txt:
         txt = FAKE_MPIRUN
     open(fake_mpirun, 'w').write(txt)
-    os.chmod(fake_mpirun, stat.S_IRUSR|stat.S_IXUSR)
+    os.chmod(fake_mpirun, stat.S_IRUSR | stat.S_IXUSR)
     os.environ['PATH'] = '%s:%s' % (path, os.getenv('PATH', ''))
     os.environ['EBROOT%s' % mpi_name.upper()] = os.path.dirname(fake_mpirun)
     os.environ['EBVERSION%s' % mpi_name.upper()] = mpi_version
@@ -182,7 +177,6 @@ class TestEnd2End(TestCase):
             text = output.read()
             self.assertTrue(regex.match(text), "Pattern '%s' found in: %s" % (regex.pattern, text))
 
-
     def test_hanging(self):
         """ Test --output-check-timeout option when program has no output"""
         no_output_mpirun = '\n'.join([
@@ -203,10 +197,10 @@ class TestEnd2End(TestCase):
         self.assertEqual(ec, 0, "Command exited normally: exit code %s; output: %s" % (ec, out))
 
         regex = re.compile(("mympirun has been running for .* seconds without seeing any output.\n"
-                            "This may mean that your program is hanging, please check and make sure that is not the case!"))
+                            "This may mean that your program is hanging, please check and make sure "
+                            "that is not the case!"))
 
         self.assertTrue(len(regex.findall(out)) == 1, "Pattern '%s' found in: %s" % (regex.pattern, out))
-
 
     def test_hanging_file(self):
         """ Test --output-check-timeout option when program has no output writing to file"""
@@ -233,7 +227,6 @@ class TestEnd2End(TestCase):
         regex = re.compile("mympirun has been running for .* seconds without seeing any output.")
         self.assertTrue(len(regex.findall(out)) == 1, "Pattern '%s' found in: %s" % (regex.pattern, out))
 
-
     def test_hanging_fatal(self):
         """Test fatal hanging check when program has no output"""
         no_output_mpirun = '\n'.join([
@@ -255,7 +248,6 @@ class TestEnd2End(TestCase):
         regex = re.compile("mympirun has been running for .* seconds without seeing any output.")
         self.assertTrue(len(regex.findall(out)) == 1, "Pattern '%s' found in: %s" % (regex.pattern, out))
 
-
     def test_option_double(self):
         """Test --double command line option"""
         install_fake_mpirun('mpirun', self.tmpdir, 'impi', '5.1.2', txt=FAKE_MPIRUN_MACHINEFILE)
@@ -263,7 +255,6 @@ class TestEnd2End(TestCase):
         # set_pbs_env() sets 2 cores, so double is 4
         self.assertEqual(out, ('\n'.join(['localhost'] * 4)))
         self.assertEqual(len(out.split('\n')), 4)
-
 
     def test_option_multi(self):
         """Test --multi command line option"""
@@ -273,14 +264,12 @@ class TestEnd2End(TestCase):
         self.assertEqual(out, ('\n'.join(['localhost'] * 6)))
         self.assertEqual(len(out.split('\n')), 6)
 
-
     def test_option_hybrid(self):
         """Test --hybrid command line option"""
         install_fake_mpirun('mpirun', self.tmpdir, 'impi', '5.1.2', txt=FAKE_MPIRUN_MACHINEFILE)
         ec, out = run([sys.executable, self.mympiscript, '--hybrid', '5', 'hostname'])
         self.assertEqual(out, ('\n'.join(['localhost'] * 5)))
         self.assertEqual(len(out.split('\n')), 5)
-
 
     def test_option_universe(self):
         """Test --universe command line option"""
@@ -315,7 +304,6 @@ class TestEnd2End(TestCase):
         """Test --universe command line option with hydra impi"""
         install_fake_mpirun('mpirun', self.tmpdir, 'impi', '5.124.67')
 
-        cmd = "%s %s --universe 1 hostname"
         ec, out = run([sys.executable, self.mympiscript, '--universe', '1', 'hostname'])
 
         np_regex = re.compile('-np 1')
@@ -466,3 +454,13 @@ class TestEnd2End(TestCase):
         # $SLURM_EXPORT_ENV should no longer be defined in environment
         regex = re.compile('SLURM_EXPORT_ENV', re.M)
         self.assertFalse(regex.search(out), "Pattern '%s' *not* found in: %s" % (regex.pattern, out))
+
+    def test_openmpi3(self):
+        """Test dry run with OpenMPI 3."""
+        install_fake_mpirun('mpirun', self.tmpdir, 'openmpi', '3.1.4')
+        ec, out = run([sys.executable, self.mympiscript, 'mpi_hello'])
+
+    def test_openmpi4(self):
+        """Test dry run with OpenMPI 4."""
+        install_fake_mpirun('mpirun', self.tmpdir, 'openmpi', '4.0.3')
+        ec, out = run([sys.executable, self.mympiscript, 'mpi_hello'])


### PR DESCRIPTION
The OpenMPI 4.0.3 we have as a part of `foss/2020a` no longer supports `openib` as BTL, because it was built with support for UCX (see https://github.com/easybuilders/easybuild-easyblocks/pull/2188).

The changes in `vsc/mympirun/mpi/openmpi.py` make sure that `--mca pml ucx` is used with OpenMPI 4.x if `ompi_info` reports `ucx` as supported PML.

The other changes are trivial style cleanups.

~~WIP, because the tests should be enhanced to cover this change~~