### PR TITLE
mympirun fixes for recent Intel MPI versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ PACKAGE = {
     'tests_require': [
         'mock',
     ],
-    'version': '5.2.1',
+    'version': '5.2.2',
     'author': [sdw, kh],
     'maintainer': [sdw, kh],
     'zip_safe': False,


### PR DESCRIPTION
* also pass down `$FI_PROVIDER*` environment variables (fixes crash when using `mympirun` with `intel/2020a` or other toolchains that include `impi` 2019.x)
* define `$I_MPI_TMPDIR` rather than `$I_MPI_MPD_TMPDIR` (>= 2019) (fixes #169)

WIP because may require fixes in tests + version bump is missing (awaiting merge of #172)