### PR TITLE
don't set $I_MPI_CPUINFO for recent Intel MPI 2019 versions

### DIFF
--- a/lib/vsc/mympirun/mpi/intelmpi.py
+++ b/lib/vsc/mympirun/mpi/intelmpi.py
@@ -278,3 +278,12 @@ class IntelMPI2019(IntelHydraMPIPbsdsh):
         self.mpiexec_global_options['I_MPI_TMPDIR'] = impi_tmpdir
         os.environ['I_MPI_TMPDIR'] = impi_tmpdir
         self.log.debug("Specified temporary directory to use via $I_MPI_TMPDIR: %s", os.environ['I_MPI_TMPDIR'])
+
+    def set_mpiexec_global_options(self):
+        """Set mpiexec global options"""
+        super(IntelMPI2019, self).set_mpiexec_global_options()
+
+        # $I_MPI_CPUINFO is no longer valid for recent Intel MPI 2019 versions, so don't set it
+        # (setting it anyway triggers a warning "I_MPI_CPUINFO environment variable is not supported")
+        if 'I_MPI_CPUINFO' in self.mpiexec_global_options:
+            del self.mpiexec_global_options['I_MPI_CPUINFO']

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ PACKAGE = {
     'tests_require': [
         'mock',
     ],
-    'version': '5.2.3',
+    'version': '5.2.4',
     'author': [sdw, kh],
     'maintainer': [sdw, kh],
     'zip_safe': False,


### PR DESCRIPTION
Recent Intel MPI 2019 versions emit a warning when `$I_MPI_CPUINFO` is set:

```
[0] MPI startup(): I_MPI_CPUINFO environment variable is not supported.
[0] MPI startup(): To check the list of supported variables, use the impi_info utility or refer to https://software.intel.com/en-us/mpi-library/documentation/get-started.
```