### PR TITLE
clean up top-level temporary run directory in $HOME + switch to use standard Python logging module

### DIFF
--- a/bin/mympirun.py
+++ b/bin/mympirun.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/mympisanity.py
+++ b/bin/mympisanity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/mympisanity.py
+++ b/bin/mympisanity.py
@@ -82,17 +82,17 @@ def check():
     # internal sanity check
     lens = [len(x) for x in recvbuf]
     if len(set(lens)) > 1:
-        log.error("Not all reports contain same amount of data (%s)" % (set(lens)))
+        log.error("Not all reports contain same amount of data (%s)", set(lens))
 
     for idx, rep in enumerate(recvbuf):
         if not idx == rep['rank']:
-            log.error('Report rank %s does not match gather index %s' % (rep['rank'], idx))
+            log.error('Report rank %s does not match gather index %s', rep['rank'], idx)
 
     # all nodes same property ?
     for prop in ['kernel']:
         props = [x[prop] for x in recvbuf]
         if len(set(props)) > 1:
-            log.error("Not all ranks report identical property %s (%s)" % (prop, set(props)))
+            log.error("Not all ranks report identical property %s (%s)", prop, set(props))
 
     # make nodes/rank structure
     hostnames = set([y['hostname'] for y in recvbuf])
@@ -106,7 +106,7 @@ def check():
         for af in afs:
             for coreid in af:
                 if coreid in res:
-                    log.error("In node %s affinity overlap on core %s found" % (node, coreid))
+                    log.error("In node %s affinity overlap on core %s found", node, coreid)
                 else:
                     res.append(coreid)
 
@@ -119,21 +119,20 @@ def check():
     else:
         for rank, (omp, af) in enumerate(zip(omps, afs)):
             if not len(af) == int(omp):
-                log.error("OMP_NUM_THREADS set for rank %s to %s does not match affinity width %s" % (rank, omp, af))
+                log.error("OMP_NUM_THREADS set for rank %s to %s does not match affinity width %s", rank, omp, af)
 
     # check for mapping
     for idx, _ in enumerate(recvbuf):
         next_idx = (idx + 1) % len(recvbuf)
         if recvbuf[idx]['hostname'] == recvbuf[next_idx]['hostname']:
             if not recvbuf[idx]['affinity'][-1] == recvbuf[next_idx]['affinity'][0] - 1:
-                log.error("No nn on same node for rank %s (aff %s) and next rank %s (aff %s)" %
-                          (idx, recvbuf[idx]['affinity'], next_idx, recvbuf[next_idx]['affinity']))
+                log.error("No nn on same node for rank %s (aff %s) and next rank %s (aff %s)",
+                          idx, recvbuf[idx]['affinity'], next_idx, recvbuf[next_idx]['affinity'])
         else:
             if not recvbuf[next_idx]['affinity'][0] == 0:
-                log.error("No nn on different nodes for rank %s (hn %s aff %s) and next rank %s (hn %s aff %s)" %
-                           (idx, recvbuf[idx]['hostname'], recvbuf[idx]['affinity'],
-                            next_idx, recvbuf[next_idx]['hostname'], recvbuf[next_idx]['affinity'])
-                          )
+                log.error("No nn on different nodes for rank %s (hn %s aff %s) and next rank %s (hn %s aff %s)",
+                          idx, recvbuf[idx]['hostname'], recvbuf[idx]['affinity'],
+                          next_idx, recvbuf[next_idx]['hostname'], recvbuf[next_idx]['affinity'])
 
 
 if __name__ == '__main__':

--- a/bin/mypmirun.py
+++ b/bin/mypmirun.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/mytaskprolog.py
+++ b/bin/mytaskprolog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/mytasks.py
+++ b/bin/mytasks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/pbsssh.sh
+++ b/bin/pbsssh.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of VSC-tools,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/__init__.py
+++ b/lib/vsc/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2020 Ghent University
+# Copyright 2011-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/__init__.py
+++ b/lib/vsc/mympirun/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2020 Ghent University
+# Copyright 2011-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/common.py
+++ b/lib/vsc/mympirun/common.py
@@ -318,7 +318,7 @@ class MpiBase(object):
                         res = mpirun_version_check(mpiversion)
                         LOGGER.debug("found mpirun version %s match for %s: %s", mpiversion, cls, res)
                     elif mpirun_version_check is None:
-                        LOGGER.debug("no mpirun version provided, skipping version check, match for %s" % cls)
+                        LOGGER.debug("no mpirun version provided, skipping version check, match for %s", cls)
                         res = True
                     else:
                         LOGGER.debug("mpi version not found, not match for %s", cls)

--- a/lib/vsc/mympirun/common.py
+++ b/lib/vsc/mympirun/common.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2020 Ghent University
+# Copyright 2011-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/common.py
+++ b/lib/vsc/mympirun/common.py
@@ -306,9 +306,10 @@ class MpiBase(object):
                     # mympirun is not compatible with OpenMPI version 2.0: this version contains a bug
                     # see https://github.com/hpcugent/vsc-mympirun/issues/113
                     if mpiname == "OpenMPI" and version_in_range(mpiversion, "2.0", "2.1"):
-                        logging.error(("OpenMPI 2.0.x uses a different naming protocol for nodes. As a result, it isn't "
-                                       "compatible with mympirun. This issue is not present in OpenMPI 1.x and it has "
-                                       "been fixed in OpenMPI 2.1 and further."))
+                        msg = "OpenMPI 2.0.x uses a different naming protocol for nodes. As a result, it isn't "
+                        msg += "compatible with mympirun. This issue is not present in OpenMPI 1.x and it has "
+                        msg += "been fixed in OpenMPI 2.1 and further."
+                        logging.error(msg)
                         sys.exit(1)
 
                     mpirun_version_check = getattr(cls, '_mpirun_version', None)

--- a/lib/vsc/mympirun/factory.py
+++ b/lib/vsc/mympirun/factory.py
@@ -28,20 +28,10 @@ mpi and scheduler class
 
 @author: Stijn De Weirdt, Jens Timmerman
 """
-
-from vsc.utils.fancylogger import getLogger
+import logging
 
 
 _coupler_class_cache = {}
-
-
-_log = getLogger('mympirun.factory', fname=False)
-
-
-class LogBase(object):
-    def __init__(self, **kwargs):
-        self.log = getLogger(self.__class__.__name__)
-        super(LogBase, self).__init__(**kwargs)
 
 
 def getinstance(mpi, sched, options):
@@ -54,7 +44,7 @@ def getinstance(mpi, sched, options):
 
     @return: an instance that is a subclass of the selected MPI and Scheduler
     """
-    base_classes = (LogBase, mpi, sched)
+    base_classes = (mpi, sched)
 
     if base_classes not in _coupler_class_cache:
         coupler_class = type(
@@ -70,5 +60,5 @@ def getinstance(mpi, sched, options):
         tmpl = "Fetched Coupler class %s from cache %s: %s"
         coupler_class = _coupler_class_cache[base_classes]
 
-    _log.debug(tmpl, base_classes, coupler_class.__name__, id(coupler_class))
+    logging.debug(tmpl, base_classes, coupler_class.__name__, id(coupler_class))
     return coupler_class(options=options.options, cmdargs=options.args)

--- a/lib/vsc/mympirun/factory.py
+++ b/lib/vsc/mympirun/factory.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2020 Ghent University
+# Copyright 2011-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/main.py
+++ b/lib/vsc/mympirun/main.py
@@ -90,8 +90,8 @@ def get_mpi_and_sched_and_options(mpim, mpiopt, schedm):
     if mpi is None:
         optionparser.log.raiseException(("No MPI class found that supports scriptname %s; isfake %s). Please use "
                                          "mympirun through one of the direct calls or make sure the mpirun command can"
-                                         " be found. Found MPI %s") %
-                                        (scriptname, isfake, ", ".join(found_mpi_names)))
+                                         " be found. Found MPI %s"),
+                                        scriptname, isfake, ", ".join(found_mpi_names))
     else:
         optionparser.log.debug("Found MPI class %s (scriptname %s; isfake %s)", mpi.__name__, scriptname, isfake)
 
@@ -119,5 +119,5 @@ def main(mpim, mpiopt, schedm):
             instance = getinstance(*instance_options)
             instance.main()
     except Exception as err:
-        fancylogger.getLogger().exception("Main failed: %s" % err)
+        fancylogger.getLogger().exception("Main failed: %s", err)
         sys.exit(1)

--- a/lib/vsc/mympirun/main.py
+++ b/lib/vsc/mympirun/main.py
@@ -25,7 +25,7 @@
 """
 CLI main functions common for mpi and pmi
 """
-
+import logging
 import os
 import pkgutil
 import sys
@@ -88,16 +88,15 @@ def get_mpi_and_sched_and_options(mpim, mpiopt, schedm):
         return None
 
     if mpi is None:
-        optionparser.log.raiseException(("No MPI class found that supports scriptname %s; isfake %s). Please use "
-                                         "mympirun through one of the direct calls or make sure the mpirun command can"
-                                         " be found. Found MPI %s"),
-                                        scriptname, isfake, ", ".join(found_mpi_names))
+        msg = "No MPI class found that supports scriptname %s; isfake %s). Please use mympirun "
+        msg += "through one of the direct calls or make sure the mpirun command can be found. Found MPI %s"
+        raise Exception(msg % (scriptname, isfake, ", ".join(found_mpi_names)))
     else:
-        optionparser.log.debug("Found MPI class %s (scriptname %s; isfake %s)", mpi.__name__, scriptname, isfake)
+        logging.debug("Found MPI class %s (scriptname %s; isfake %s)", mpi.__name__, scriptname, isfake)
 
     if sched is None:
-        optionparser.log.raiseException("No sched class found (options.schedtype %s ; found Sched classes %s)",
-                                        sched_name, ", ".join(found_sched_names))
+        msg = "No sched class found (options.schedtype %s ; found Sched classes %s)"
+        raise Exception(msg % (sched_name, ", ".join(found_sched_names)))
     else:
         optionparser.log.debug("Found sched class %s from options.schedtype %s (all Sched found %s)",
                                sched.__name__, sched_name, ", ".join(found_sched_names))
@@ -119,5 +118,5 @@ def main(mpim, mpiopt, schedm):
             instance = getinstance(*instance_options)
             instance.main()
     except Exception as err:
-        fancylogger.getLogger().exception("Main failed: %s", err)
+        logging.error(err)
         sys.exit(1)

--- a/lib/vsc/mympirun/main.py
+++ b/lib/vsc/mympirun/main.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2020 Ghent University
+# Copyright 2011-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/__init__.py
+++ b/lib/vsc/mympirun/mpi/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/intelmpi.py
+++ b/lib/vsc/mympirun/mpi/intelmpi.py
@@ -27,7 +27,7 @@ Intel MPI specific class
 
 Documentation can be found at https://software.intel.com/en-us/node/528769
 """
-
+import logging
 import os
 import socket
 import tempfile
@@ -81,7 +81,7 @@ class IntelMPI(MPI):
         """Has HYDRA or not"""
         mgr = os.environ.get('I_MPI_PROCESS_MANAGER', None)
         if mgr == 'mpd':
-            self.log.debug("No hydra, I_MPI_PROCESS_MANAGER set to %s", mgr)
+            logging.debug("No hydra, I_MPI_PROCESS_MANAGER set to %s", mgr)
             return False
         else:
             return super(IntelMPI, self)._has_hydra()
@@ -104,7 +104,7 @@ class IntelMPI(MPI):
         impi_tmpdir = tempfile.gettempdir()
         self.mpiexec_global_options['I_MPI_MPD_TMPDIR'] = impi_tmpdir
         os.environ['I_MPI_MPD_TMPDIR'] = impi_tmpdir
-        self.log.debug("Set intel temp dir based on I_MPI_MPD_TMPDIR: %s", os.environ['I_MPI_MPD_TMPDIR'])
+        logging.debug("Set intel temp dir based on I_MPI_MPD_TMPDIR: %s", os.environ['I_MPI_MPD_TMPDIR'])
 
     def set_mpiexec_global_options(self):
         """Set mpiexec global options"""
@@ -148,9 +148,9 @@ class IntelMPI(MPI):
             if 'TMI_CONFIG' in os.environ:
                 tmicfg = os.environ.get('TMI_CONFIG')
                 if not os.path.exists(tmicfg):
-                    self.log.error('TMI_CONFIG set (%s), but not found.', tmicfg)
+                    logging.error('TMI_CONFIG set (%s), but not found.', tmicfg)
             elif not os.path.exists('/etc/tmi.conf'):
-                self.log.debug("No TMI_CONFIG and no /etc/tmi.conf found, creating one")
+                logging.debug("No TMI_CONFIG and no /etc/tmi.conf found, creating one")
                 # make the psm tmi config
                 tmicfg = os.path.join(self.mympirundir, '..', 'intelmpi.tmi.conf')
                 if not os.path.exists(tmicfg):
@@ -162,7 +162,7 @@ class IntelMPI(MPI):
                 self.mpiexec_global_options['TMI_DEBUG'] = '1'
 
             if self.options.pinmpi:
-                self.log.debug('Have PSM set affinity (disable I_MPI_PIN)')
+                logging.debug('Have PSM set affinity (disable I_MPI_PIN)')
                 self.mpiexec_global_options['I_MPI_PIN'] = '0'
 
     def mpirun_prepare_execution(self):
@@ -176,7 +176,7 @@ class IntelMPI(MPI):
     def pinning_override(self):
         """ pinning """
 
-        self.log.debug("pinning_override: type %s ", self.pinning_override_type)
+        logging.debug("pinning_override: type %s ", self.pinning_override_type)
 
         cmd = CmdList()
         if self.pinning_override_type in ('packed', 'compact', 'bunch'):
@@ -184,8 +184,7 @@ class IntelMPI(MPI):
         elif self.pinning_override_type in ('spread', 'scatter'):
             cmd.add(['-env', 'I_MPI_PIN_PROCESSOR_LIST=allcores:map=%s' % self.pinning_override_type])
         else:
-            self.log.raiseException("pinning_override: unsupported pinning_override_type  %s" %
-                                    self.pinning_override_type)
+            raise Exception("pinning_override: unsupported pinning_override_type  %s" % self.pinning_override_type)
 
         return cmd
 
@@ -247,7 +246,7 @@ class IntelHydraMPI(IntelMPI):
 
         if self.options.impi_daplud:
             if self.options.impi_xrc:
-                self.log.warning('Ignoring XRC setting when also requesting UD')
+                logging.warning('Ignoring XRC setting when also requesting UD')
             self.mpiexec_global_options['I_MPI_DAPL_UD'] = _enable_disable(self.options.impi_daplud)
             if 'I_MPI_DAPL_UD_PROVIDER' not in os.environ:
                 self.mpiexec_global_options['I_MPI_DAPL_UD_PROVIDER'] = 'ofa-v2-mlx4_0-1u'
@@ -277,7 +276,7 @@ class IntelMPI2019(IntelHydraMPIPbsdsh):
         impi_tmpdir = tempfile.gettempdir()
         self.mpiexec_global_options['I_MPI_TMPDIR'] = impi_tmpdir
         os.environ['I_MPI_TMPDIR'] = impi_tmpdir
-        self.log.debug("Specified temporary directory to use via $I_MPI_TMPDIR: %s", os.environ['I_MPI_TMPDIR'])
+        logging.debug("Specified temporary directory to use via $I_MPI_TMPDIR: %s", os.environ['I_MPI_TMPDIR'])
 
     def set_mpiexec_global_options(self):
         """Set mpiexec global options"""

--- a/lib/vsc/mympirun/mpi/intelmpi.py
+++ b/lib/vsc/mympirun/mpi/intelmpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2020 Ghent University
+# Copyright 2011-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -699,7 +699,7 @@ class MPI(MpiBase):
                 if (env_prefix == env_var or env_var.startswith("%s_" % env_prefix)) and env_var not in vars_to_pass:
                     self.mpiexec_opts_from_env.append(env_var)
 
-        self.log.debug("Vars passed: %s" % self.mpiexec_opts_from_env)
+        self.log.debug("Vars passed: %s", str(self.mpiexec_opts_from_env))
 
     def set_mpiexec_options(self):
         """Add various options to mpiexec_options."""
@@ -752,10 +752,10 @@ class MPI(MpiBase):
             self.log.debug("Using specified launcher: %s", launcher)
             if launcher not in avail_launchers:
                 err = "Specified launcher %s does not exist, available launchers: %s"
-                self.log.warning(err % (launcher, avail_launchers))
+                self.log.warning(err, launcher, avail_launchers)
         else:
             if default_launcher:
-                self.log.debug("No launcher specified, using default launcher: %s" % default_launcher)
+                self.log.debug("No launcher specified, using default launcher: %s", default_launcher)
                 launcher = default_launcher
             else:
                 self.log.raiseException("There is no launcher specified, and no default launcher found")
@@ -796,8 +796,8 @@ class MPI(MpiBase):
             key = key.strip().lower()
             value = regex.groupdict()['value']
             if value is None:
-                self.log.debug("get_hydra_info: failed to get hydra info: missing value in %s (out: %s)" %
-                               (regex.groupdict(), out))
+                self.log.debug("get_hydra_info: failed to get hydra info: missing value in %s (out: %s)",
+                               str(regex.groupdict()), out)
                 value = ''
             values = [x.strip().strip('"').strip("'") for x in value.split() if x.strip()]
             hydra_info[key] = values

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -709,7 +709,7 @@ class MPI(MpiBase):
                 if (env_prefix == env_var or env_var.startswith("%s_" % env_prefix)) and env_var not in vars_to_pass:
                     self.mpiexec_opts_from_env.append(env_var)
 
-        logging.debug("Vars passed: %s" % self.mpiexec_opts_from_env)
+        logging.debug("Vars passed: %s", str(self.mpiexec_opts_from_env))
 
     def set_mpiexec_options(self):
         """Add various options to mpiexec_options."""
@@ -762,10 +762,10 @@ class MPI(MpiBase):
             logging.debug("Using specified launcher: %s", launcher)
             if launcher not in avail_launchers:
                 err = "Specified launcher %s does not exist, available launchers: %s"
-                logging.warning(err % (launcher, avail_launchers))
+                logging.warning(err, launcher, avail_launchers)
         else:
             if default_launcher:
-                logging.debug("No launcher specified, using default launcher: %s" % default_launcher)
+                logging.debug("No launcher specified, using default launcher: %s", default_launcher)
                 launcher = default_launcher
             else:
                 msg = "There is no launcher specified, and no default launcher found"
@@ -810,8 +810,8 @@ class MPI(MpiBase):
             key = key.strip().lower()
             value = regex.groupdict()['value']
             if value is None:
-                logging.debug("get_hydra_info: failed to get hydra info: missing value in %s (out: %s)" %
-                               (regex.groupdict(), out))
+                msg = "get_hydra_info: failed to get hydra info: missing value in %s (out: %s)"
+                logging.debug(msg, str(regex.groupdict()), out)
                 value = ''
             values = [x.strip().strip('"').strip("'") for x in value.split() if x.strip()]
             hydra_info[key] = values

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -901,9 +901,9 @@ class MPI(MpiBase):
         self.log.raiseException("pinning_override: not implemented.")
 
     def cleanup(self):
-        """Remove temporary directory (mympirundir)"""
+        """Remove top-level temporary run directory"""
         try:
-            shutil.rmtree(self.mympirundir)
-            self.log.debug("cleanup: removed mympirundir %s", self.mympirundir)
+            shutil.rmtree(self.mympirunbasedir)
+            self.log.debug("cleanup: removed mympirundir %s", self.mympirunbasedir)
         except OSError as err:
-            self.log.raiseException("cleanup: cleaning up mympirundir %s failed: %s", self.mympirundir, err)
+            self.log.raiseException("cleanup: cleaning up mympirundir %s failed: %s", self.mympirunbasedir, err)

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2020 Ghent University
+# Copyright 2011-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/mpich.py
+++ b/lib/vsc/mympirun/mpi/mpich.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2020 Ghent University
+# Copyright 2011-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -26,6 +26,7 @@
 OpenMPI specific classes
 Documentation can be found at https://www.open-mpi.org/doc/
 """
+import logging
 import os
 import re
 import sys
@@ -107,17 +108,17 @@ class OpenMPI(MPI):
             except IOError as err:
                 error_msg = "Failed to read /proc/cpuinfo to determine number of sockets per node: %s" % err
                 error_msg += "; use --sockets-per-node to override"
-                self.log.error(error_msg)
+                logging.error(error_msg)
                 sys.exit(1)
 
             if proc_cpuinfo:
                 res = re.findall('^physical id.*', proc_cpuinfo, re.M)
                 sockets_per_node = len(nub(res))
-                self.log.debug("Sockets per node found in cpuinfo: set to %s", sockets_per_node)
+                logging.debug("Sockets per node found in cpuinfo: set to %s", sockets_per_node)
 
             if sockets_per_node == 0:
-                self.log.warning("Could not derive number of sockets per node from /proc/cpuinfo. "
-                                 "Assuming a single socket, use --sockets-per-node to override.")
+                logging.warning("Could not derive number of sockets per node from /proc/cpuinfo. "
+                                "Assuming a single socket, use --sockets-per-node to override.")
                 sockets_per_node = 1
 
         return sockets_per_node
@@ -127,7 +128,7 @@ class OpenMPI(MPI):
 
         override_type = self.pinning_override_type
 
-        self.log.debug("pinning_override: type %s ", override_type)
+        logging.debug("pinning_override: type %s ", override_type)
 
         ranktxt = ""
         sockets_per_node = self.determine_sockets_per_node()
@@ -153,16 +154,15 @@ class OpenMPI(MPI):
                     ranktxt += "rank %i=+n%i slot=%i:%i\n" % (rank, node, socket, slot)
 
             else:
-                self.log.raiseException("pinning_override: unsupported pinning_override_type  %s" %
-                                        self.pinning_override_type)
+                raise Exception("pinning_override: unsupported pinning_override_type  %s" % self.pinning_override_type)
 
             with open(rankfn, 'w') as fp:
                 fp.write(ranktxt)
-            self.log.debug("pinning_override: wrote rankfile %s:\n%s", rankfn, ranktxt)
+            logging.debug("pinning_override: wrote rankfile %s:\n%s", rankfn, ranktxt)
             cmd = CmdList('-rf', rankfn)
 
         except IOError as err:
-            self.log.raiseException('pinning_override: failed to write rankfile %s: %s' % (rankfn, err))
+            raise Exception('pinning_override: failed to write rankfile %s: %s' % (rankfn, err))
 
         return cmd
 
@@ -200,7 +200,7 @@ class OpenMPI(MPI):
         # (unless OpenMPI installation was configured with --enable-orterun-prefix-by-default)
         # cfr. https://www.mail-archive.com/devel@lists.open-mpi.org/msg17305.html
         if SLURM_EXPORT_ENV in os.environ:
-            self.log.info("Undefining $%s (was '%s')", SLURM_EXPORT_ENV, os.getenv(SLURM_EXPORT_ENV))
+            logging.info("Undefining $%s (was '%s')", SLURM_EXPORT_ENV, os.getenv(SLURM_EXPORT_ENV))
             del os.environ[SLURM_EXPORT_ENV]
 
         super(OpenMPI, self).prepare()
@@ -260,7 +260,7 @@ class OpenMpi4(OpenMpi3):
         cmd = "ompi_info"
         ec, out = run(cmd)
         if ec:
-            self.log.raiseException("use_ucx_pml: failed to run cmd '%s', ec: %s, out: %s" % (cmd, ec, out))
+            raise Exception("use_ucx_pml: failed to run cmd '%s', ec: %s, out: %s" % (cmd, ec, out))
 
         pml_ucx_pattern = ' pml: ucx '
         return bool(re.search(pml_ucx_pattern, out))

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -113,7 +113,7 @@ class OpenMPI(MPI):
             if proc_cpuinfo:
                 res = re.findall('^physical id.*', proc_cpuinfo, re.M)
                 sockets_per_node = len(nub(res))
-                self.log.debug("Sockets per node found in cpuinfo: set to %s" % sockets_per_node)
+                self.log.debug("Sockets per node found in cpuinfo: set to %s", sockets_per_node)
 
             if sockets_per_node == 0:
                 self.log.warning("Could not derive number of sockets per node from /proc/cpuinfo. "

--- a/lib/vsc/mympirun/mpi/option.py
+++ b/lib/vsc/mympirun/mpi/option.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/option.py
+++ b/lib/vsc/mympirun/option.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/__init__.py
+++ b/lib/vsc/mympirun/pmi/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/mpi.py
+++ b/lib/vsc/mympirun/pmi/mpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Ghent University
+# Copyright 2019-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/mpi.py
+++ b/lib/vsc/mympirun/pmi/mpi.py
@@ -28,11 +28,10 @@ Base PMI MPI class, all actual classes should inherit from this one
 The role of the MPI class is very limited, mainly to provide supported PMI flavour/version
 """
 from __future__ import print_function
-
+import logging
 import os
 import re
 
-from vsc.utils.fancylogger import getLogger
 from vsc.utils.run import run
 from vsc.mympirun.common import MpiBase, eb_root_version, version_in_range
 from vsc.mympirun.pmi.pmi import PMIv2, PMIxv3
@@ -62,9 +61,6 @@ class MPI(MpiBase):
 
     def __init__(self, options, cmdargs, **kwargs):
         """Initialise, named attributes are passed to parent MpiBase class"""
-        if not hasattr(self, 'log'):
-            self.log = getLogger(self.__class__.__name__)
-
         self.options = options
         self.cmdargs = cmdargs
 
@@ -75,7 +71,7 @@ class MPI(MpiBase):
 
         # sanity checks
         if not self.cmdargs and not self.options.print_launcher:
-            self.log.raiseException("__init__: no executable or command provided")
+            raise Exception("__init__: no executable or command provided")
 
     def main(self):
         """
@@ -90,14 +86,14 @@ class MPI(MpiBase):
             print(' '.join(pmicmd))
             exitcode = 0
         elif self.options.dry_run:
-            self.log.info("Dry run, only printing generated mpirun command...")
+            logging.info("Dry run, only printing generated mpirun command...")
             print(' '.join(cmd))
             exitcode = 0
         else:
             exitcode, _ = run_function(cmd)
 
         if exitcode > 0:
-            self.log.raiseException("main: exitcode %s > 0; cmd %s" % (exitcode, cmd))
+            raise Exception("main: exitcode %s > 0; cmd %s" % (exitcode, cmd))
 
     def _eb_has(self, name, txt=None):
         """Determine is the is a EB module loaded for name"""
@@ -106,10 +102,10 @@ class MPI(MpiBase):
 
         root, version = eb_root_version(name)
         if root:
-            self.log.debug("Found %s root %s version %s", txt, root, version)
+            logging.debug("Found %s root %s version %s", txt, root, version)
             return True
         else:
-            self.log.debug("No %s root / version found", txt)
+            logging.debug("No %s root / version found", txt)
             return False
 
     def has_ucx(self):
@@ -133,23 +129,23 @@ class MPI(MpiBase):
         if self.PMI is None:
             # TODO: detect somehow
             #   this is hard because most likely it will use the system pmi libraries
-            self.log.error("Detecting PMI is not implemented")
+            logging.error("Detecting PMI is not implemented")
             return None
         else:
-            self.log.debug("Has PMI %s (forced)", self.PMI)
+            logging.debug("Has PMI %s (forced)", self.PMI)
             return self.PMI
 
     def mpi_tune_hcoll_mpi(self):
         """MPI specific HCOLL tuning/enabling"""
-        self.log.debug("No MPI-specific hcoll tuning")
+        logging.debug("No MPI-specific hcoll tuning")
 
     def mpi_tune_mpi(self):
         """MPI specific tuning/enabling"""
-        self.log.debug("No MPI-specific MPI tuning")
+        logging.debug("No MPI-specific MPI tuning")
 
     def mpi_tune_ucx_mpi(self):
         """MPI specific UCX tuning/enabling"""
-        self.log.debug("No MPI-specific UCX tuning")
+        logging.debug("No MPI-specific UCX tuning")
 
     def mpi_tune(self):
         """
@@ -161,7 +157,7 @@ class MPI(MpiBase):
             # TODO: tag matching: UCX_RC_VERBS_TM_ENABLE=y ?
             self.mpi_tune_ucx_mpi()
         else:
-            self.log.debug("No UCX found, so no UCX tuning")
+            logging.debug("No UCX found, so no UCX tuning")
 
         if self.hcoll:
             # mpi hcoll settings
@@ -175,7 +171,7 @@ class MPI(MpiBase):
             self.set_env('HCOLL_CUDA_SBGP', 'p2p', keep=True)
             self.set_env('HCOLL_CUDA_BCOL', 'nccl', keep=True)
         else:
-            self.log.debug("No hcoll found, no hcoll tuning")
+            logging.debug("No hcoll found, no hcoll tuning")
 
     def get_pmi2_lib(self, pref=None):
         """Locate the pmi2 libs"""
@@ -188,28 +184,28 @@ class MPI(MpiBase):
         for name in pref:
             lib = PMI2LIBS[name]
             if name == AUTOMATIC_LIB:
-                self.log.debug("Using %s nonexisting PMIv2 lib %s from %s (%s)", AUTOMATIC_LIB, lib, pref, PMI2LIBS)
+                logging.debug("Using %s nonexisting PMIv2 lib %s from %s (%s)", AUTOMATIC_LIB, lib, pref, PMI2LIBS)
                 return lib
             elif os.path.isfile(lib):
-                self.log.debug("Found PMIv2 lib %s from %s (%s)", lib, pref, PMI2LIBS)
+                logging.debug("Found PMIv2 lib %s from %s (%s)", lib, pref, PMI2LIBS)
                 return lib
 
-        self.log.error("Cannot find PMIv2 lib from %s (%s)", pref, PMI2LIBS)
+        logging.error("Cannot find PMIv2 lib from %s (%s)", pref, PMI2LIBS)
         return None
 
     def mpi_pmi(self):
         """
         Enable PMI e.g. via environment variables.
         """
-        self.log.debug("Nothing to do to enable PMI")
+        logging.debug("Nothing to do to enable PMI")
 
     def mpi_debug_mpi(self):
         """MPI specific debugging"""
-        self.log.debug("No MPI debugging")
+        logging.debug("No MPI debugging")
 
     def mpi_debug_ucx_mpi(self):
         """MPI specific UCX debugging"""
-        self.log.debug("No MPI-speciifc UCX debugging")
+        logging.debug("No MPI-speciifc UCX debugging")
 
     def mpi_debug(self):
         """
@@ -239,10 +235,10 @@ class MPI(MpiBase):
         if hybrid is None:
             if mpi_info.gpus is not None:
                 hybrid = mpi_info.gpus
-                self.log.debug("Setting number of GPUs %s as hybrid value", hybrid)
+                logging.debug("Setting number of GPUs %s as hybrid value", hybrid)
 
         if hybrid is not None:
-            self.log.debug("Setting hybrid %s number of ranks", hybrid)
+            logging.debug("Setting hybrid %s number of ranks", hybrid)
             mpi_info.ranks = hybrid
             self.set_env('OMP_NUM_THREADS', max(1, mpi_info.cores // hybrid))
 
@@ -267,7 +263,7 @@ class OpenMPI31xOr4x(MPI):
         cmd = "ompi_info"
         ec, out = run(cmd)
         if ec:
-            self.log.raiseException("has_ucx: failed to run cmd '%s', ec: %s, out: %s" % (cmd, ec, out))
+            raise Exception("has_ucx: failed to run cmd '%s', ec: %s, out: %s" % (cmd, ec, out))
 
         ompi_info_pml_ucx = bool(re.search(' pml: ucx ', out))
 

--- a/lib/vsc/mympirun/pmi/option.py
+++ b/lib/vsc/mympirun/pmi/option.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Ghent University
+# Copyright 2019-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/pmi.py
+++ b/lib/vsc/mympirun/pmi/pmi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Ghent University
+# Copyright 2019-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/sched.py
+++ b/lib/vsc/mympirun/pmi/sched.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Ghent University
+# Copyright 2019-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/sched.py
+++ b/lib/vsc/mympirun/pmi/sched.py
@@ -27,10 +27,9 @@ Base PMI Sched class, all actual classes should inherit from this one
 
 The role of the Sched class is mainly to construct the correct sched-specific PMI call
 """
-
+import logging
 import os
 from copy import deepcopy
-from vsc.utils.fancylogger import getLogger
 from vsc.mympirun.common import SchedBase
 from vsc.utils.run import run_file, async_to_stdout
 
@@ -66,8 +65,6 @@ class Sched(SchedBase):
     LAUNCHER = None
 
     def __init__(self, options=None, **kwargs):
-        if not hasattr(self, 'log'):
-            self.log = getLogger(self.__class__.__name__)
         if not hasattr(self, 'options'):
             self.options = options
 
@@ -82,12 +79,12 @@ class Sched(SchedBase):
         """
         current = os.environ.get(key)
         if keep and current is not None:
-            self.log.debug("Keeping existing environment variable %s with value %s (ignore value %s)",
-                           key, current, value)
+            logging.debug("Keeping existing environment variable %s with value %s (ignore value %s)",
+                          key, current, value)
         else:
             os.environ[key] = str(value)
             self.envs.append(key)
-            self.log.debug("Set environment variable %s: %s", key, value)
+            logging.debug("Set environment variable %s: %s", key, value)
 
     def pmicmd(self):
         """
@@ -100,11 +97,11 @@ class Sched(SchedBase):
         for name in ['tune', 'pmi', 'debug']:
             method_name = 'mpi_' + name
             getattr(self, method_name)()
-            self.log.debug("Calling %s", method_name)
+            logging.debug("Calling %s", method_name)
 
         for name in ['sched', 'sizing', 'environment', 'mpi', 'debug']:
             args = getattr(self, 'pmicmd_' + name)()
-            self.log.debug("Generated pmicmd %s arguments %s", name, args)
+            logging.debug("Generated pmicmd %s arguments %s", name, args)
             pmicmd.extend(args)
 
         run_function, run_function_args = self.run_function()
@@ -112,7 +109,7 @@ class Sched(SchedBase):
 
         pmicmd.extend(['--' + x for x in getattr(self.options, 'pass', [])])  # .pass gives syntax error?
 
-        self.log.debug("Generated pmicmd %s", pmicmd)
+        logging.debug("Generated pmicmd %s", pmicmd)
         return pmicmd, run_function
 
     def run_function(self):
@@ -135,28 +132,28 @@ class Sched(SchedBase):
         """
         Fill in/complete/edit job_info dict and return it
         """
-        self.log.warn("Nothing done with job_info %s", job_info)
+        logging.warn("Nothing done with job_info %s", job_info)
         return job_info
 
     def pmicmd_size_args(self, mpi_info):
         """
         Convert mpi_info into launcher list of args
         """
-        self.log.warn("Nothing done with mpi_info %s, no args generated", mpi_info)
+        logging.warn("Nothing done with mpi_info %s, no args generated", mpi_info)
         return []
 
     def pmicmd_sizing(self):
         """Generate the sizing arguments to the launcher as a list"""
         job_info = self.job_info(Info())
-        self.log.debug("Got job info %s", job_info)
+        logging.debug("Got job info %s", job_info)
 
         # compute requested
         mpi_info = self.mpi_size(job_info)
-        self.log.debug("Got mpi size info %s", mpi_info)
+        logging.debug("Got mpi size info %s", mpi_info)
 
         # generate args
         args = self.pmicmd_size_args(mpi_info)
-        self.log.debug("Got pmi cmd args %s", args)
+        logging.debug("Got pmi cmd args %s", args)
 
         return args
 
@@ -166,7 +163,7 @@ class Sched(SchedBase):
 
         Modified envs should be tracked via self.envs
         """
-        self.log.debug("No environment specific arguments (assuming whole environment is used)")
+        logging.debug("No environment specific arguments (assuming whole environment is used)")
         return []
 
     def pmicmd_mpi(self):

--- a/lib/vsc/mympirun/pmi/slurm.py
+++ b/lib/vsc/mympirun/pmi/slurm.py
@@ -25,7 +25,7 @@
 """
 Slurm PMI class, i.e. wrap around srun
 """
-
+import logging
 import os
 import re
 
@@ -84,22 +84,21 @@ class Slurm(Sched):
                 if pmi.VERSION == 3:
                     flavour += '_v3'
                 else:
-                    self.log.warn("Unsupported PMIx version %s, trying with generic %s", pmi, flavour)
+                    logging.warn("Unsupported PMIx version %s, trying with generic %s", pmi, flavour)
             elif pmi.FLAVOUR == PMI:
                 if pmi.VERSION == 2:
                     flavour = 'pmi2'
                 else:
-                    self.log.raiseException("Unsupported PMI version %s" % pmi)
+                    raise Exception("Unsupported PMI version %s" % pmi)
             else:
-                self.log.raiseException("Unsupported PMI %s" % pmi)
+                raise Exception("Unsupported PMI %s" % pmi)
 
             if flavour is not None:
                 # first one wins
-                self.log.debug("Mapped PMI %s to flavour %s", pmi, flavour)
+                logging.debug("Mapped PMI %s to flavour %s", pmi, flavour)
                 return ["--mpi=%s" % flavour]
 
-        self.log.raiseException("No supported PMIs")
-        return []
+        raise Exception("No supported PMIs")
 
     def job_info(self, job_info):
         """
@@ -118,7 +117,7 @@ class Slurm(Sched):
         dbgtxt = ', '.join(['%s=%s' % (k, v) for k, v in sorted(os.environ.items()) if k.startswith('SLURM_')])
 
         if 'SLURM_PACK_SIZE' in os.environ:
-            self.log.raiseException("This is an inhomogenous job (PACK_SIZE set): %s" % dbgtxt)
+            raise Exception("This is an inhomogenous job (PACK_SIZE set): %s" % dbgtxt)
 
         nodes = int(os.environ['SLURM_NNODES'])
         cores = int(os.environ['SLURM_CPUS_ON_NODE'])
@@ -127,20 +126,20 @@ class Slurm(Sched):
 
         # add sanity checks
         if nodes * cores != int(os.environ['SLURM_NPROCS']):
-            self.log.raiseException("This is an inhomogenous job: nodes*cores!=nprocs: %s" % dbgtxt)
+            raise Exception("This is an inhomogenous job: nodes*cores!=nprocs: %s" % dbgtxt)
         else:
-            self.log.debug("SLURM env variables %s", dbgtxt)
+            logging.debug("SLURM env variables %s", dbgtxt)
 
         total_tasks = int(os.environ['SLURM_NTASKS'])
 
         job_info.ranks = total_tasks // nodes
         if total_tasks % nodes:
-            self.log.raiseException("Total number of tasks is not equal ranks per node %s time number of nodes: %s" %
-                                    (job_info.ranks, dbgtxt))
+            msg = "Total number of tasks is not equal ranks per node %s time number of nodes: %s"
+            raise Exception(msg % (job_info.ranks, dbgtxt))
 
         mem = os.environ.get('SLURM_MEM_PER_NODE', int(os.environ.get('SLURM_MEM_PER_CPU', -1)) * cores)
         if mem < 0:
-            self.log.debug("No memory specification found")
+            logging.debug("No memory specification found")
         else:
             job_info.mem = int(mem)
 
@@ -149,7 +148,7 @@ class Slurm(Sched):
                 # this should fail when slurm switched to compressed repr (eg 0-3 instead of current 0,1,2,3)
                 ngpus = len(list(map(int, os.environ['SLURM_JOB_GPUS'].split(','))))
             except Exception as e:
-                self.log.raiseException("Failed to get the number of gpus per node from %s: %s" % (dbgtxt, e))
+                raise Exception("Failed to get the number of gpus per node from %s: %s" % (dbgtxt, e))
 
             job_info.gpus = ngpus
 
@@ -176,9 +175,9 @@ class Slurm(Sched):
                 del os.environ[key]
 
         if removed:
-            self.log.debug("Unset environment variables %s", " ".join(removed))
+            logging.debug("Unset environment variables %s", " ".join(removed))
         else:
-            self.log.debug("No environment variables unset")
+            logging.debug("No environment variables unset")
 
         args = []
 
@@ -190,7 +189,7 @@ class Slurm(Sched):
 
         # sanity check
         if mpi_info.cores % mpi_info.ranks:
-            self.log.raiseException("Imbalanced cores and ranks per node %s" % mpi_info)
+            raise Exception("Imbalanced cores and ranks per node %s" % mpi_info)
         else:
             # cores per task == cores per rank
             args.append("--cpus-per-task=%s" % (mpi_info.cores // mpi_info.ranks))
@@ -198,20 +197,20 @@ class Slurm(Sched):
 
         # redistribute all the memory to the tasks/cores
         if mpi_info.mem is None:
-            self.log.debug("No memory specified (assuming slurm.conf defaults)")
+            logging.debug("No memory specified (assuming slurm.conf defaults)")
         else:
             args.append("--mem-per-cpu=%s" % (mpi_info.mem // mpi_info.cores))
 
         if mpi_info.gpus is not None:
             if self.options.all_gpus:
                 # TODO: this is not slurm specific, needs to be factored out
-                self.log.debug("Not limiting gpus per rank, gpus-all set")
+                logging.debug("Not limiting gpus per rank, gpus-all set")
             elif mpi_info.gpus < mpi_info.ranks:
                 # enable MPS
                 #   probably also needs to check for imbalance
-                self.log.raiseException("MPS not supported yet: %s" % mpi_info)
+                raise Exception("MPS not supported yet: %s" % mpi_info)
             elif mpi_info.gpus % mpi_info.ranks:
-                self.log.raiseException("Imbalanced tasks and gpus per node (ranks < gpus): %s" % mpi_info)
+                raise Exception("Imbalanced tasks and gpus per node (ranks < gpus): %s" % mpi_info)
             else:
                 args.append("--gpus-per-task=%s" % (mpi_info.gpus // mpi_info.ranks))
 
@@ -241,5 +240,5 @@ class Tasks(Slurm):
 
     def pmicmd_mpi(self):
         """Disable mpi"""
-        self.log.debug("No mpi in mytasks")
+        logging.debug("No mpi in mytasks")
         return ["--mpi=none"]

--- a/lib/vsc/mympirun/pmi/slurm.py
+++ b/lib/vsc/mympirun/pmi/slurm.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Ghent University
+# Copyright 2019-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/__init__.py
+++ b/lib/vsc/mympirun/rm/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/local.py
+++ b/lib/vsc/mympirun/rm/local.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/local.py
+++ b/lib/vsc/mympirun/rm/local.py
@@ -25,6 +25,8 @@
 """
 Local scheduler : no scheduler, act on single node
 """
+import logging
+
 from vsc.mympirun.rm.sched import Sched
 
 
@@ -52,7 +54,7 @@ class Local(Sched):
         self.nodes_uniq = [localhostname]
         self.nodes = self.nodes_uniq * self.nodes_tot_cnt
 
-        self.log.debug("set_nodes: cnt: %d; uniq: %s", self.nodes_tot_cnt, self.nodes_uniq)
+        logging.debug("set_nodes: cnt: %d; uniq: %s", self.nodes_tot_cnt, self.nodes_uniq)
 
     def is_local(self):
         """

--- a/lib/vsc/mympirun/rm/pbs.py
+++ b/lib/vsc/mympirun/rm/pbs.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/pbs.py
+++ b/lib/vsc/mympirun/rm/pbs.py
@@ -25,6 +25,7 @@
 """
 Torque / PBS
 """
+import logging
 import os
 
 from vsc.mympirun.common import which
@@ -54,29 +55,29 @@ class PBS(Sched):
         # pbsssh is only used if native support for pbsdsh is not supported in the MPI library;
         # e.g. Intel MPI v5.x and newer supports using pbsdsh as launcher natively, no need for pbsssh wrapper
         if which(PBSSSH) and which(PBSDSH):
-            self.log.debug("Both 'pbsssh' and 'pbsdsh' found, so using 'pbsssh' as remote shell command.")
+            logging.debug("Both 'pbsssh' and 'pbsdsh' found, so using 'pbsssh' as remote shell command.")
             self.RSH_LARGE_CMD = PBSSSH
             self.HYDRA_LAUNCHER_EXEC = PBSSSH
         elif which(PBSSSH):
-            self.log.debug("Can't use '%s' wrapper if '%s' is not available", PBSDSH, PBSSSH)
+            logging.debug("Can't use '%s' wrapper if '%s' is not available", PBSDSH, PBSSSH)
         else:
-            self.log.debug("'%s' wrapper not available, so can't use it", PBSSSH)
+            logging.debug("'%s' wrapper not available, so can't use it", PBSSSH)
 
-        self.log.info("Using '%s' as remote shell command", self.get_rsh())
+        logging.info("Using '%s' as remote shell command", self.get_rsh())
 
     def set_nodes(self):
 
         filename = os.environ.get(self.SCHED_ENVIRON_NODE_INFO)
         if filename is None:
-            self.log.raiseException("set_nodes: failed to get $%s from environment" % self.SCHED_ENVIRON_NODE_INFO)
+            raise Exception("set_nodes: failed to get $%s from environment" % self.SCHED_ENVIRON_NODE_INFO)
 
         try:
             self.nodes = [x.strip() for x in open(filename).read().split("\n") if len(x.strip()) > 0]
-            self.log.debug("set_nodes: from %s: %s", filename, self.nodes)
+            logging.debug("set_nodes: from %s: %s", filename, self.nodes)
         except IOError:
-            self.log.raiseException("set_nodes: failed to get nodes from nodefile %s" % filename)
+            raise Exception("set_nodes: failed to get nodes from nodefile %s" % filename)
 
         self.nodes_uniq = nub(self.nodes)
         self.nodes_tot_cnt = len(self.nodes)
 
-        self.log.debug("set_nodes: %s (cnt: %d; uniq: %s)", self.nodes, self.nodes_tot_cnt, self.nodes_uniq)
+        logging.debug("set_nodes: %s (cnt: %d; uniq: %s)", self.nodes, self.nodes_tot_cnt, self.nodes_uniq)

--- a/lib/vsc/mympirun/rm/sched.py
+++ b/lib/vsc/mympirun/rm/sched.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/sched.py
+++ b/lib/vsc/mympirun/rm/sched.py
@@ -83,10 +83,10 @@ class Sched(SchedBase):
         ppn = os.environ.get('PBS_NUM_PPN')
         if ppn is not None:
             self.ppn = int(ppn)
-            self.log.debug("Determined # cores per node via $PBS_NUM_PPN: %s" % self.ppn)
+            self.log.debug("Determined # cores per node via $PBS_NUM_PPN: %s", self.ppn)
         else:
             self.ppn = len(self.cpus)
-            self.log.debug("Failed to determine # cores per node via $PBS_NUM_PPN, using affinity: found %s" % self.ppn)
+            self.log.debug("Failed to determine # cores per node via $PBS_NUM_PPN, using affinity: found %s", self.ppn)
         self.set_ppn()
 
         self.mpinodes = None
@@ -149,7 +149,7 @@ class Sched(SchedBase):
         for node in self.nodes:
             self.ppn_dict.setdefault(node, 0)
             self.ppn_dict[node] += 1
-        self.log.debug("Number of processors per node: %s" % self.ppn_dict)
+        self.log.debug("Number of processors per node: %s", str(self.ppn_dict))
 
     def get_rsh(self):
         """Determine remote shell command"""
@@ -218,8 +218,8 @@ class Sched(SchedBase):
                 random.seed(seed)
                 self.log.debug("set_mpinodes: setting random seed %s", seed)
             random.shuffle(res)
-            self.log.debug("set_mpinodes shuffled nodes (mode %s)" %
-                           ordermode)
+            self.log.debug("set_mpinodes shuffled nodes (mode %s)", ordermode)
+
         elif ordermode[0] in ('sort',):
             res.sort()
             self.log.debug("set_mpinodes sort nodes (mode %s)", ordermode)

--- a/lib/vsc/mympirun/rm/scoop.py
+++ b/lib/vsc/mympirun/rm/scoop.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/slurm.py
+++ b/lib/vsc/mympirun/rm/slurm.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2020 Ghent University
+# Copyright 2018-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/slurm.py
+++ b/lib/vsc/mympirun/rm/slurm.py
@@ -61,7 +61,7 @@ class SLURM(Sched):
         else:
             res = out.strip().split('\n')
 
-        self.log.debug("_get_uniq_nodes: %s" % res)
+        self.log.debug("_get_uniq_nodes: %s", res)
         return res
 
     def _get_tasks_per_node(self):
@@ -86,7 +86,7 @@ class SLURM(Sched):
                 else:
                     tpn.append(int(entry))
 
-        self.log.debug("_get_tasks_per_node: %s" % tpn)
+        self.log.debug("_get_tasks_per_node: %s", tpn)
         return tpn
 
     def set_nodes(self):

--- a/lib/vsc/mympirun/rm/slurm.py
+++ b/lib/vsc/mympirun/rm/slurm.py
@@ -25,6 +25,7 @@
 """
 SLURM
 """
+import logging
 import os
 import re
 
@@ -50,18 +51,18 @@ class SLURM(Sched):
 
         nodelist = os.environ.get(self.SCHED_ENVIRON_NODE_INFO)
         if nodelist is None:
-            self.log.raiseException("set_nodes: failed to get $%s from environment" % self.SCHED_ENVIRON_NODE_INFO)
+            raise Exception("set_nodes: failed to get $%s from environment" % self.SCHED_ENVIRON_NODE_INFO)
         else:
-            self.log.debug("set_nodes: obtained $%s value: %s", self.SCHED_ENVIRON_NODE_INFO, nodelist)
+            logging.debug("set_nodes: obtained $%s value: %s", self.SCHED_ENVIRON_NODE_INFO, nodelist)
 
         cmd = "scontrol show hostname %s" % nodelist
         ec, out = run(cmd)
         if ec:
-            self.log.raiseException("set_nodes: failed to get list of unique hostnames using '%s': %s" % (cmd, out))
+            raise Exception("set_nodes: failed to get list of unique hostnames using '%s': %s" % (cmd, out))
         else:
             res = out.strip().split('\n')
 
-        self.log.debug("_get_uniq_nodes: %s", res)
+        logging.debug("_get_uniq_nodes: %s", res)
         return res
 
     def _get_tasks_per_node(self):
@@ -73,9 +74,9 @@ class SLURM(Sched):
         tpn_key = 'SLURM_TASKS_PER_NODE'
         tpn_spec = os.environ.get(tpn_key)
         if tpn_spec is None:
-            self.log.raiseException("set_nodes: failed to get $%s from environment" % tpn_key)
+            raise Exception("set_nodes: failed to get $%s from environment" % tpn_key)
         else:
-            self.log.debug("set_nodes: obtained $%s value: %s", tpn_key, tpn_spec)
+            logging.debug("set_nodes: obtained $%s value: %s", tpn_key, tpn_spec)
             # duplicate counts are compacted into something like '2(x3)', so we unroll those
             compact_regex = re.compile(r'^(?P<task_cnt>\d+)\(x(?P<repeat_cnt>\d+)\)$')
             tpn = []
@@ -86,7 +87,7 @@ class SLURM(Sched):
                 else:
                     tpn.append(int(entry))
 
-        self.log.debug("_get_tasks_per_node: %s", tpn)
+        logging.debug("_get_tasks_per_node: %s", tpn)
         return tpn
 
     def set_nodes(self):
@@ -96,7 +97,7 @@ class SLURM(Sched):
         tpn = self._get_tasks_per_node()
 
         if len(self.nodes_uniq) != len(tpn):
-            self.log.raiseException("nodes_uniq vs tpn (tasks per node) mismatch: %s vs %s" % (self.nodes_uniq, tpn))
+            raise Exception("nodes_uniq vs tpn (tasks per node) mismatch: %s vs %s" % (self.nodes_uniq, tpn))
 
         self.nodes_tot_cnt = sum(tpn)
 
@@ -104,4 +105,4 @@ class SLURM(Sched):
         for (node, task_cnt) in zip(self.nodes_uniq, tpn):
             self.nodes.extend([node] * task_cnt)
 
-        self.log.debug("set_nodes: %s (cnt: %d; uniq: %s)", self.nodes, self.nodes_tot_cnt, self.nodes_uniq)
+        logging.debug("set_nodes: %s (cnt: %d; uniq: %s)", self.nodes, self.nodes_tot_cnt, self.nodes_uniq)

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ PACKAGE = {
     'tests_require': [
         'mock',
     ],
-    'version': '5.2.5',
+    'version': '5.2.6',
     'author': [sdw, kh],
     'maintainer': [sdw, kh],
     'zip_safe': False,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: latin-1 -*-
 #
-# Copyright 2009-2020 Ghent University
+# Copyright 2009-2021 Ghent University
 #
 # This file is part of VSC-tools,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/00-import.py
+++ b/test/00-import.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2020 Ghent University
+# Copyright 2016-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2020 Ghent University
+# Copyright 2016-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -415,7 +415,7 @@ class TestEnd2End(TestCase):
 
         # unknown launcher being specified only results in a warning (we allow specifying launchers that are not listed)
         ec, out = run([sys.executable, self.mympiscript, '--launcher', 'doesnotexist', 'hostname'])
-        regex = r'WARNING .* Specified launcher doesnotexist does not exist'
+        regex = r'WARNING.*Specified launcher doesnotexist does not exist'
         fail_msg = "mympirun should warn for non-existing launcher; pattern '%s' should be found in: %s"
         self.assertTrue(re.search(regex, out), fail_msg % (regex, out))
 

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2020 Ghent University
+# Copyright 2012-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -416,7 +416,8 @@ class TestEnd2End(TestCase):
         # unknown launcher being specified only results in a warning (we allow specifying launchers that are not listed)
         ec, out = run([sys.executable, self.mympiscript, '--launcher', 'doesnotexist', 'hostname'])
         regex = r'WARNING .* Specified launcher doesnotexist does not exist'
-        self.assertTrue(re.search(regex, out), "mympirun should warn for non-existing launcher")
+        fail_msg = "mympirun should warn for non-existing launcher; pattern '%s' should be found in: %s"
+        self.assertTrue(re.search(regex, out), fail_msg % (regex, out))
 
         ec, out = run([sys.executable, self.mympiscript, '--sched', 'local', 'hostname'])
         self.assertFalse("-bootstrap" in out, "using local scheduler, no bootstrap launcher should be specified: " + out)

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -234,7 +234,7 @@ class TestMPI(TestCase):
         # disable make_mympirundir
         mpi_instance.make_mympirundir = lambda: True
         mpi_instance.mympirundir = '/does/not/exist/'
-        self.assertErrorRegex(IOError, "failed to write nodefile", mpi_instance.make_machine_file)
+        self.assertErrorRegex(Exception, "/does/not/exist", mpi_instance.make_machine_file)
 
         # openmpi oversubscribing
         mpi_instance = getinstance(OpenMpiOversubscribe, Local, MympirunOption())

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2020 Ghent University
+# Copyright 2012-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/mytaskprolog.py
+++ b/test/mytaskprolog.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Ghent University
+# Copyright 2019-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/mytasks.py
+++ b/test/mytasks.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Ghent University
+# Copyright 2019-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/pmi_e2e.py
+++ b/test/pmi_e2e.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Ghent University
+# Copyright 2019-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/pmi_slurm.py
+++ b/test/pmi_slurm.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Ghent University
+# Copyright 2019-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/pmi_utils.py
+++ b/test/pmi_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2020 Ghent University
+# Copyright 2019-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/sched.py
+++ b/test/sched.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2020 Ghent University
+# Copyright 2012-2021 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),


### PR DESCRIPTION
We were just cleaning up a subdirectory, not the top-level directory that is created in `make_mympirundir`... 🤦 
The actual fix is in the `cleanup` method in `lib/vsc/mympirun/mpi/mpi.py`

fixes #151

This PR also cleans up the logging mess, by avoiding the use of `fancylogger's` `getLogger`, and using the standard `logging` or `raise Exception` instead. A couple of minor tweaks were needed for the tests as a result, but nothing major.

I've also done some basic tests with the resulting mympirun 5.2.6 installation (MPI hello + some OSU benchmark runs), and checked error reporting, all seems to be working as expected...