### PR TITLE
use --map-by core --bind-to core by default with OpenMPI (WIP)

### DIFF
--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -85,10 +85,16 @@ class OpenMPI(MPI):
         """Set mpiexec options"""
         super(OpenMPI, self).set_mpiexec_options()
 
-        # specify number of processes to start per node if --hybrid is used
         if self.options.hybrid:
+            # specify number of processes to start per node if --hybrid is used
             procs_per_node = self.multiplier * self.options.hybrid
             self.mpiexec_options.add(['--map-by', 'ppr:%s:node' % procs_per_node])
+        else:
+            # map MPI processes by core (default is --map-by numa),
+            # and bind to core (default is --bind-to numa' when # ranks > 2),
+            # to match default behaviour of Intel MPI;
+            # this is important for performance for OpenFOAM for example, especially on AMD Rome CPUs
+            self.mpiexec_options.add(['--map-by', 'core', '--bind-to', 'core'])
 
     def _make_final_mpirun_cmd(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ PACKAGE = {
     'tests_require': [
         'mock',
     ],
-    'version': '5.2.7-test',
+    'version': '5.2.7',
     'author': [sdw, kh],
     'maintainer': [sdw, kh],
     'zip_safe': False,

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ PACKAGE = {
     'tests_require': [
         'mock',
     ],
-    'version': '5.2.6',
+    'version': '5.2.7-test',
     'author': [sdw, kh],
     'maintainer': [sdw, kh],
     'zip_safe': False,

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -507,6 +507,10 @@ class TestEnd2End(TestCase):
         regex = re.compile(r"^fake mpirun called with args:.*--mca btl \^uct")
         self.assertTrue(regex.search(out), "Pattern '%s' should be found in: %s" % (regex.pattern, out))
 
+        # mapping/binding to core is done by default
+        regex = re.compile(r"^fake mpirun called with args:.*--map-by core --bind-to core")
+        self.assertTrue(regex.search(out), "Pattern '%s' should be found in: %s" % (regex.pattern, out))
+
         # BTL self should not be specified when UCX is used as PML (but 'btl ^uct' is specified)
         regex = re.compile("--mca btl .*self")
         self.assertFalse(regex.search(out), "Pattern '%s' should not be found in: %s" % (regex.pattern, out))


### PR DESCRIPTION
to ensure sequential ranking/pinning of MPI processes by cores (rather than by NUMA domain)

Still WIP, since I want to catch this in the tests too (actually, the fact that the tests still pass while making a change like this is bad imho)