### PR TITLE
disable libfabric (OFI) btl + mtl by default when using OpenMPI (HPC-11091)

### DIFF
--- a/bin/mympirun.py
+++ b/bin/mympirun.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/mympisanity.py
+++ b/bin/mympisanity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/mypmirun.py
+++ b/bin/mypmirun.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/mytaskprolog.py
+++ b/bin/mytaskprolog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/mytasks.py
+++ b/bin/mytasks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/__init__.py
+++ b/lib/vsc/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2023 Ghent University
+# Copyright 2011-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/__init__.py
+++ b/lib/vsc/mympirun/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2023 Ghent University
+# Copyright 2011-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/common.py
+++ b/lib/vsc/mympirun/common.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2023 Ghent University
+# Copyright 2011-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/factory.py
+++ b/lib/vsc/mympirun/factory.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2023 Ghent University
+# Copyright 2011-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/main.py
+++ b/lib/vsc/mympirun/main.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2023 Ghent University
+# Copyright 2011-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/__init__.py
+++ b/lib/vsc/mympirun/mpi/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/intelmpi.py
+++ b/lib/vsc/mympirun/mpi/intelmpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2023 Ghent University
+# Copyright 2011-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2023 Ghent University
+# Copyright 2011-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -601,8 +601,7 @@ class MPI(MpiBase):
                              "(text file with minimal entry 'password=<somesecretpassword>')"), mpdconffn)
 
             with open(mpdconffn, 'w') as mpdconff:
-                mpdconff.write("password=" + ''.join(random.choice(string.ascii_uppercase + string.digits)
-                                                     for x in range(10)))
+                mpdconff.write("password=" + ''.join(random.choices(string.ascii_uppercase + string.digits, k=10)))
             # set correct permissions on this file.
             os.chmod(mpdconffn, stat.S_IREAD)
 

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -601,8 +601,8 @@ class MPI(MpiBase):
                              "(text file with minimal entry 'password=<somesecretpassword>')"), mpdconffn)
 
             with open(mpdconffn, 'w') as mpdconff:
-                mpdconff.write("password=%s" % ''.join(random.choice(string.ascii_uppercase + string.digits)
-                                                       for x in range(10)))
+                mpdconff.write("password=" + ''.join(random.choice(string.ascii_uppercase + string.digits)
+                                                     for x in range(10)))
             # set correct permissions on this file.
             os.chmod(mpdconffn, stat.S_IREAD)
 

--- a/lib/vsc/mympirun/mpi/mpich.py
+++ b/lib/vsc/mympirun/mpi/mpich.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2023 Ghent University
+# Copyright 2011-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -70,7 +70,8 @@ class OpenMPI(MPI):
 
         if self.use_ucx_pml():
             self.mpiexec_global_options['pml'] = 'ucx'
-            # always disable uct btl when using UCX, see https://openucx.readthedocs.io/en/master/running.html#runtime-tunings
+            # always disable uct btl when using UCX,
+            # see https://openucx.readthedocs.io/en/master/running.html#runtime-tunings
             if self.options.libfabric:
                 self.mpiexec_global_options['btl'] = '^uct'
             else:

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -70,8 +70,15 @@ class OpenMPI(MPI):
 
         if self.use_ucx_pml():
             self.mpiexec_global_options['pml'] = 'ucx'
-            # disable uct btl, see http://openucx.github.io/ucx/running.html
-            self.mpiexec_global_options['btl'] = '^uct'
+            # always disable uct btl when using UCX, see https://openucx.readthedocs.io/en/master/running.html#runtime-tunings
+            if self.options.libfabric:
+                self.mpiexec_global_options['btl'] = '^uct'
+            else:
+                # also disable libfabric (OFI) btl, since it can cause trouble on Infiniband systems
+                self.mpiexec_global_options['btl'] = '^uct,ofi'
+                # disable libfabric (OFI) mtl as well
+                self.mpiexec_global_options['mtl'] = '^ofi'
+
             if self.options.debuglvl > 3:
                 os.environ['UCX_LOG_LEVEL'] = 'debug'
                 self.mpiexec_global_options['pml_ucx_verbose'] = self.options.debuglvl

--- a/lib/vsc/mympirun/mpi/option.py
+++ b/lib/vsc/mympirun/mpi/option.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/option.py
+++ b/lib/vsc/mympirun/mpi/option.py
@@ -46,6 +46,8 @@ class MympirunOption(CommonOption):
         "launcher": ("The launcher to be used by Hydra (used in recent Intel MPI versions (> 4.1))"
                      "for example: ssh, pbsdsh, ..", "str", "store", None),
 
+        "libfabric": ("Allow use of libfabric", None, "store_true", False),
+
         "mpdbootverbose": ("Run verbose mpdboot", None, "store_true", False),
 
         "mpirunoptions": ("String with options to pass to mpirun (will be appended to generate command)",

--- a/lib/vsc/mympirun/option.py
+++ b/lib/vsc/mympirun/option.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/__init__.py
+++ b/lib/vsc/mympirun/pmi/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/mpi.py
+++ b/lib/vsc/mympirun/pmi/mpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2023 Ghent University
+# Copyright 2019-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/option.py
+++ b/lib/vsc/mympirun/pmi/option.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2023 Ghent University
+# Copyright 2019-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/option.py
+++ b/lib/vsc/mympirun/pmi/option.py
@@ -45,7 +45,7 @@ class MypmirunOption(CommonOption):
                  "strlist", "store", []),
         'print-launcher': ("Generate and print the launcher command", None, "store_true", None),
         'distribute': (("Start ranks in a certain distribution on nodes/sockets/cores: "
-                        "%s groups them, %s spreads them") % (DISTRIBUTE_PACK, DISTRIBUTE_CYCLE),
+                        f"{DISTRIBUTE_PACK} groups them, {DISTRIBUTE_CYCLE} spreads them"),
                        None, "store", None, [DISTRIBUTE_PACK, DISTRIBUTE_CYCLE]),
         'all-gpus': ("Each rank sees all (requested) gpus", None, "store_true", None),
     }

--- a/lib/vsc/mympirun/pmi/pmi.py
+++ b/lib/vsc/mympirun/pmi/pmi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2023 Ghent University
+# Copyright 2019-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/sched.py
+++ b/lib/vsc/mympirun/pmi/sched.py
@@ -53,9 +53,8 @@ class Info:
 
     def __str__(self):
         """Human readable"""
-        res = f"{self.nodes} nodes; with per node {self.cores} cores, {self.ranks} ranks, "
-        res += "{self.mem} mem, {self.gpus} gpus"
-        return res
+        return (f"{self.nodes} nodes; with per node {self.cores} cores, "
+            f"{self.ranks} ranks, {self.mem} mem, {self.gpus} gpus")
 
     def deepcopy(self):
         """Return a (deep)copy"""

--- a/lib/vsc/mympirun/pmi/sched.py
+++ b/lib/vsc/mympirun/pmi/sched.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2023 Ghent University
+# Copyright 2019-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/sched.py
+++ b/lib/vsc/mympirun/pmi/sched.py
@@ -53,8 +53,9 @@ class Info:
 
     def __str__(self):
         """Human readable"""
-        return "{} nodes; with per node {} cores, {} ranks, {} mem, {} gpus".format(
-            self.nodes, self.cores, self.ranks, self.mem, self.gpus)
+        res = f"{self.nodes} nodes; with per node {self.cores} cores, {self.ranks} ranks, "
+        res += "{self.mem} mem, {self.gpus} gpus"
+        return res
 
     def deepcopy(self):
         """Return a (deep)copy"""

--- a/lib/vsc/mympirun/pmi/slurm.py
+++ b/lib/vsc/mympirun/pmi/slurm.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2023 Ghent University
+# Copyright 2019-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/__init__.py
+++ b/lib/vsc/mympirun/rm/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/local.py
+++ b/lib/vsc/mympirun/rm/local.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/pbs.py
+++ b/lib/vsc/mympirun/rm/pbs.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/sched.py
+++ b/lib/vsc/mympirun/rm/sched.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/sched.py
+++ b/lib/vsc/mympirun/rm/sched.py
@@ -102,8 +102,9 @@ class Sched(SchedBase):
             if self.AUTOGENERATE_JOBID:
                 logging.info("set_sched_id: failed to get id from environment variable %s, will generate one.",
                              self.SCHED_ENVIRON_ID)
-                self.sched_id = "SCHED_%s%s%05d" % (self.__class__.__name__, time.strftime("%Y%m%d%H%M%S"),
-                                                    random.randint(0, 10 ** 5 - 1))
+                timestamp = time.strftime("%Y%m%d%H%M%S")
+                random_int_val = random.randint(0, 10 ** 5 - 1)
+                self.sched_id = f"SCHED_{self.__class__.__name__}{timestamp}{random_int_val:05d}"
                 logging.debug("set_sched_id: using generated id %s", self.sched_id)
             else:
                 raise Exception(f"set_sched_id: failed to get id from environment variable {self.SCHED_ENVIRON_ID}")

--- a/lib/vsc/mympirun/rm/scoop.py
+++ b/lib/vsc/mympirun/rm/scoop.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/slurm.py
+++ b/lib/vsc/mympirun/rm/slurm.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2023 Ghent University
+# Copyright 2018-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ PACKAGE = {
     'tests_require': [
         'mock',
     ],
-    'version': '5.3.2',
+    'version': '5.4.0',
     'author': [sdw, kh],
     'maintainer': [sdw, kh],
     'zip_safe': False,

--- a/test/00-import.py
+++ b/test/00-import.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2023 Ghent University
+# Copyright 2016-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2023 Ghent University
+# Copyright 2016-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2023 Ghent University
+# Copyright 2012-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2023 Ghent University
+# Copyright 2012-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/mytaskprolog.py
+++ b/test/mytaskprolog.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2023 Ghent University
+# Copyright 2019-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/mytasks.py
+++ b/test/mytasks.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2023 Ghent University
+# Copyright 2019-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/pmi_e2e.py
+++ b/test/pmi_e2e.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2023 Ghent University
+# Copyright 2019-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/pmi_slurm.py
+++ b/test/pmi_slurm.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2023 Ghent University
+# Copyright 2019-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/pmi_utils.py
+++ b/test/pmi_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2023 Ghent University
+# Copyright 2019-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/sched.py
+++ b/test/sched.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2023 Ghent University
+# Copyright 2012-2024 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,17 @@
 envlist = py36,py39
 skipsdist = true
 
-[testenv]
+[testenv:py36]
 commands_pre =
     pip install 'setuptools<42.0'
     python -m easy_install -U vsc-install
+
+[testenv:py39]
+setenv = SETUPTOOLS_USE_DISTUTILS=local
+commands_pre =
+    pip install 'setuptools<54.0' wheel
+    python -c "from setuptools import setup;setup(script_args=['-q', 'easy_install', '-v', '-U', 'vsc-install'])"
+
+[testenv]
 commands = python setup.py test
 passenv = USER


### PR DESCRIPTION
Motivation for this are the inconsistent errors "`Failed to modify UD QP to INIT on mlx5_0: Operation not permitted`" that we have been seeing after updating to OFED 23.10.

Worth noting, same can be achieved in contexts where `mympirun` is not used via:

```
export OMPI_MCA_btl='^uct,ofi'
export OMPI_MCA_pml='ucx'
export OMPI_MCA_mtl='^ofi'
```