### PR TITLE
fix issues with Intel MPI after update to Slurm 25.11.3 and OFED 24.10 (hcoll 4.8.3230)

### DIFF
--- a/bin/mympirun.py
+++ b/bin/mympirun.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/mympisanity.py
+++ b/bin/mympisanity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/mypmirun.py
+++ b/bin/mypmirun.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/mytaskprolog.py
+++ b/bin/mytaskprolog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/bin/mytasks.py
+++ b/bin/mytasks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/__init__.py
+++ b/lib/vsc/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2025 Ghent University
+# Copyright 2011-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/__init__.py
+++ b/lib/vsc/mympirun/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2025 Ghent University
+# Copyright 2011-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/common.py
+++ b/lib/vsc/mympirun/common.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2025 Ghent University
+# Copyright 2011-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/factory.py
+++ b/lib/vsc/mympirun/factory.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2025 Ghent University
+# Copyright 2011-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/main.py
+++ b/lib/vsc/mympirun/main.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2025 Ghent University
+# Copyright 2011-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/__init__.py
+++ b/lib/vsc/mympirun/mpi/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/intelmpi.py
+++ b/lib/vsc/mympirun/mpi/intelmpi.py
@@ -38,6 +38,7 @@ from vsc.mympirun.common import version_in_range, which
 from vsc.mympirun.mpi.mpi import MPI, RM_HYDRA_LAUNCHER
 
 SCALABLE_PROGRESS_LOWER_THRESHOLD = 64
+SLURM_EXPORT_ENV = 'SLURM_EXPORT_ENV'
 
 
 def _enable_disable(boolvalue):
@@ -226,7 +227,7 @@ class IntelHydraMPI(IntelMPI):
     MPDBOOT_SET_INTERFACE = False
 
     DEVICE_MPIDEVICE_MAP = {
-        'ib': 'shm:dapl',
+        'ib': 'shm:ofi',
         'det': 'det',
         'shm': 'shm',
         'socket': 'shm:tcp',
@@ -267,9 +268,9 @@ class IntelHydraMPIPbsdsh(IntelHydraMPI):
 
 
 class IntelMPI2019(IntelHydraMPIPbsdsh):
-    """MPI class for Intel MPI version 2019 and more recent."""
+    """MPI class for Intel MPI version 2019 and more recent (until 2021.9)"""
 
-    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '2019.0', None))
+    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '2019.0', '2021.9'))
 
     def set_impi_tmpdir(self):
         """Set location of temporary directory that Intel MPI should use."""
@@ -287,3 +288,42 @@ class IntelMPI2019(IntelHydraMPIPbsdsh):
         # (setting it anyway triggers a warning "I_MPI_CPUINFO environment variable is not supported")
         if 'I_MPI_CPUINFO' in self.mpiexec_global_options:
             del self.mpiexec_global_options['I_MPI_CPUINFO']
+
+
+class IntelMPI20219(IntelMPI2019):
+    """MPI class for Intel MPI version 2021.9 and more recent."""
+
+    _mpirun_version = staticmethod(lambda ver: version_in_range(ver, '2021.9', None))
+
+    def prepare(self):
+        """Prepare environment"""
+        # undefine $SLURM_EXPORT_ENV if it is set;
+        # $SLURM_EXPORT_ENV is defined as 'NONE' by qsub wrappers for SLURM,
+        # and then gets passed down to srun via mpirun,
+        # this may cause problems because $PATH and $LD_LIBRARY_PATH are no longer set
+        if SLURM_EXPORT_ENV in os.environ:
+            logging.info("Undefining $%s (was '%s')", SLURM_EXPORT_ENV, os.getenv(SLURM_EXPORT_ENV))
+            del os.environ[SLURM_EXPORT_ENV]
+
+        super().prepare()
+
+    def set_mpiexec_global_options(self):
+        """Set mpiexec global options"""
+        super().set_mpiexec_global_options()
+
+        # disable the external collective operations functionality,
+        # required because external hcoll library may be incompatible with UCX being used
+        self.mpiexec_global_options['I_MPI_COLL_EXTERNAL'] = '0'
+
+        # unset environment variables for which support has been removed,
+        # since having them set trigger warnings about being ignored
+        removed_env_vars = [
+            'I_MPI_DAT_LIBRARY',
+            'I_MPI_DAPL_SCALABLE_PROGRESS',
+            'I_MPI_FALLBACK_DEVICE',
+            'I_MPI_FALLBACK',
+            'I_MPI_NETMASK',
+        ]
+        for env_var in removed_env_vars:
+            if env_var in self.mpiexec_global_options:
+                del self.mpiexec_global_options[env_var]

--- a/lib/vsc/mympirun/mpi/intelmpi.py
+++ b/lib/vsc/mympirun/mpi/intelmpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2025 Ghent University
+# Copyright 2011-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/mpi.py
+++ b/lib/vsc/mympirun/mpi/mpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2025 Ghent University
+# Copyright 2011-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/mpich.py
+++ b/lib/vsc/mympirun/mpi/mpich.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2025 Ghent University
+# Copyright 2011-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/openmpi.py
+++ b/lib/vsc/mympirun/mpi/openmpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/mpi/option.py
+++ b/lib/vsc/mympirun/mpi/option.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/option.py
+++ b/lib/vsc/mympirun/option.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/__init__.py
+++ b/lib/vsc/mympirun/pmi/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/mpi.py
+++ b/lib/vsc/mympirun/pmi/mpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2025 Ghent University
+# Copyright 2019-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/option.py
+++ b/lib/vsc/mympirun/pmi/option.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2025 Ghent University
+# Copyright 2019-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/pmi.py
+++ b/lib/vsc/mympirun/pmi/pmi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2025 Ghent University
+# Copyright 2019-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/sched.py
+++ b/lib/vsc/mympirun/pmi/sched.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2025 Ghent University
+# Copyright 2019-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/pmi/slurm.py
+++ b/lib/vsc/mympirun/pmi/slurm.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2025 Ghent University
+# Copyright 2019-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/__init__.py
+++ b/lib/vsc/mympirun/rm/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/local.py
+++ b/lib/vsc/mympirun/rm/local.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/pbs.py
+++ b/lib/vsc/mympirun/rm/pbs.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/sched.py
+++ b/lib/vsc/mympirun/rm/sched.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/scoop.py
+++ b/lib/vsc/mympirun/rm/scoop.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/mympirun/rm/slurm.py
+++ b/lib/vsc/mympirun/rm/slurm.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2025 Ghent University
+# Copyright 2018-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of VSC-tools,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ PACKAGE = {
     'tests_require': [
         'mock',
     ],
-    'version': '5.5.0',
+    'version': '5.5.1',
     'author': [sdw, kh],
     'maintainer': [sdw, kh],
     'zip_safe': False,

--- a/test/00-import.py
+++ b/test/00-import.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2025 Ghent University
+# Copyright 2016-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2025 Ghent University
+# Copyright 2016-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/end2end.py
+++ b/test/end2end.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2025 Ghent University
+# Copyright 2012-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/mpi.py
+++ b/test/mpi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2025 Ghent University
+# Copyright 2012-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/mytaskprolog.py
+++ b/test/mytaskprolog.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2025 Ghent University
+# Copyright 2019-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/mytasks.py
+++ b/test/mytasks.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2025 Ghent University
+# Copyright 2019-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/pmi_e2e.py
+++ b/test/pmi_e2e.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2025 Ghent University
+# Copyright 2019-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/pmi_slurm.py
+++ b/test/pmi_slurm.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2025 Ghent University
+# Copyright 2019-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/pmi_utils.py
+++ b/test/pmi_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2025 Ghent University
+# Copyright 2019-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/sched.py
+++ b/test/sched.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2025 Ghent University
+# Copyright 2012-2026 Ghent University
 #
 # This file is part of vsc-mympirun,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),


### PR DESCRIPTION
This fixes a number of problems.

Unsetting `$SLURM_EXPORT_ENV` fixes the following problem:
```
[mpiexec@node5643.dodrio.os] check_exit_codes (../../../../../src/pm/i_hydra/libhydra/demux/hydra_demux_poll.c:121): unable to run bstrap_proxy (pid 906931, exit code 256)
[mpiexec@node5643.dodrio.os] poll_for_event (../../../../../src/pm/i_hydra/libhydra/demux/hydra_demux_poll.c:159): check exit codes error
[mpiexec@node5643.dodrio.os] HYD_dmx_poll_wait_for_proxy_event (../../../../../src/pm/i_hydra/libhydra/demux/hydra_demux_poll.c:212): poll for event error
[mpiexec@node5643.dodrio.os] HYD_bstrap_setup (../../../../../src/pm/i_hydra/libhydra/bstrap/src/intel/i_hydra_bstrap.c:1065): error waiting for event
[mpiexec@node5643.dodrio.os] HYD_print_bstrap_setup_error_message (../../../../../src/pm/i_hydra/mpiexec/intel/i_mpiexec.c:1027): error setting up the bootstrap proxies
[mpiexec@node5643.dodrio.os] Possible reasons:
[mpiexec@node5643.dodrio.os] 1. Host is unavailable. Please check that all hosts are available.
[mpiexec@node5643.dodrio.os] 2. Cannot launch hydra_bstrap_proxy or it crashed on one of the hosts. Make sure hydra_bstrap_proxy is available on all hosts and it has right permissions.
[mpiexec@node5643.dodrio.os] 3. Firewall refused connection. Check that enough ports are allowed in the firewall and specify them with the I_MPI_PORT_RANGE variable.
[mpiexec@node5643.dodrio.os] 4. slurm bootstrap cannot launch processes on remote host. You may try using -bootstrap option to select alternative launcher.
```

That's related to a change in updated Slurm:
```
$ sbatch --version
slurm 25.11.3
```

Setting `$I_MPI_COLL_EXTERNAL` to `0` fixes the following nasty crash with a segfault due to an incompatibility with the new `hcoll` installed on the system (along with updated OFED):
```
$ rpm -qa | grep hcoll
hcoll-4.8.3230-1.2410068.x86_64
$ rpm -q mlnx-ofa_kernel
mlnx-ofa_kernel-24.10-OFED.24.10.3.2.5.1.rhel9u6.x86_64
```
```
[node5643:901423:0:901423] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x208)
==== backtrace (tid: 901428) ====
 0 0x000000000003ebf0 __GI___sigaction()  :0
 1 0x0000000000278b71 MPIDIG_dequeue_unexp()  /build/impi/_buildspace/release/../../src/mpid/ch4/src/intel/ch4r_unexp_hashtable.c:416
 2 0x00000000003a58d9 MPIDIG_do_irecv()  /build/impi/_buildspace/release/../../src/mpid/ch4/generic/am/mpidig_am_recv.h:135
 3 0x00000000003c7d08 MPIDIG_mpi_irecv()  /build/impi/_buildspace/release/../../src/mpid/ch4/generic/am/mpidig_am_recv.h:331
 4 0x00000000003c7d08 MPIDI_POSIX_mpi_irecv()  /build/impi/_buildspace/release/../../src/mpid/ch4/shm/posix/../src/../posix/posix_recv.h:55
 5 0x00000000003c7d08 MPIDI_SHM_mpi_irecv()  /build/impi/_buildspace/release/../../src/mpid/ch4/shm/posix/../src/shm_p2p.h:325
 6 0x00000000003c7d08 MPIDI_irecv_unsafe()  /build/impi/_buildspace/release/../../src/mpid/ch4/src/ch4_recv.h:253
 7 0x00000000003c7d08 MPIDI_irecv_safe()  /build/impi/_buildspace/release/../../src/mpid/ch4/src/ch4_recv.h:563
 8 0x00000000003c7d08 MPID_Irecv()  /build/impi/_buildspace/release/../../src/mpid/ch4/src/ch4_recv.h:793
 9 0x00000000003c7d08 MPIC_Irecv()  /build/impi/_buildspace/release/../../src/mpi/coll/helper_fns.c:649
10 0x000000000039c61e recv_nb()  /build/impi/_buildspace/release/../../src/mpid/common/hcoll/hcoll_rte.c:228
11 0x000000000001c5a3 comm_allreduce_hcolrte_generic()  ???:0
12 0x000000000001cf70 comm_allreduce_hcolrte()  ???:0
13 0x000000000001a7b0 hmca_bcol_ucx_p2p_init_query()  ???:0
14 0x00000000000b51f3 hmca_bcol_base_init()  ???:0
15 0x0000000000063ac3 hmca_coll_ml_init_query()  ???:0
16 0x00000000000ac2b5 hcoll_init_with_opts()  ???:0
17 0x000000000039a723 hcoll_initialize()  /build/impi/_buildspace/release/../../src/mpid/common/hcoll/hcoll_init.c:101
18 0x000000000039a723 hcoll_comm_create()  /build/impi/_buildspace/release/../../src/mpid/common/hcoll/hcoll_init.c:139
19 0x000000000062e50b MPIDI_OFI_mpi_comm_commit_pre_hook()  /build/impi/_buildspace/release/../../src/mpid/ch4/netmod/ofi/ofi_comm.c:211
20 0x00000000001e6ea5 MPID_Comm_commit_pre_hook()  /build/impi/_buildspace/release/../../src/mpid/ch4/src/ch4_comm.c:192
21 0x000000000030c45e MPIR_Comm_commit_internal()  /build/impi/_buildspace/release/../../src/mpi/comm/commutil.c:708
22 0x000000000030c45e MPIR_Comm_commit()  /build/impi/_buildspace/release/../../src/mpi/comm/commutil.c:896
23 0x0000000000229de5 init_builtin_comms()  /build/impi/_buildspace/release/../../src/mpid/ch4/src/ch4_init.c:1298
24 0x0000000000229de5 MPID_Init()  /build/impi/_buildspace/release/../../src/mpid/ch4/src/ch4_init.c:1628
25 0x00000000004ced80 MPIR_Init_thread()  /build/impi/_buildspace/release/../../src/mpi/init/initthread.c:175
26 0x00000000004ce63b PMPI_Init()  /build/impi/_buildspace/release/../../src/mpi/init/init.c:139
27 0x00000000004010bb main()  ???:0
28 0x00000000000295d0 __libc_start_call_main()  ???:0
29 0x0000000000029680 __libc_start_main_alias_2()  :0
30 0x0000000000401255 _start()  ???:0
=================================
```

Using `shm:ofi` in `DEVICE_MPIDEVICE_MAP` fixes a warning:
```
MPI startup(): shm:dapl fabric is unknown or has been removed from the product, please use ofi or shm:ofi instead
```

unsetting the other `$I_MPI_*` environment variables fixes the following warnings:
```
MPI startup(): I_MPI_DAT_LIBRARY variable has been removed from the product, its value is ignored

MPI startup(): I_MPI_DAPL_SCALABLE_PROGRESS variable has been removed from the product, its value is ignored

MPI startup(): I_MPI_FALLBACK_DEVICE environment variable is not supported.
MPI startup(): Similar variables:
         I_MPI_OFFLOAD_DEVICES
MPI startup(): I_MPI_NETMASK environment variable is not supported.
MPI startup(): I_MPI_FALLBACK environment variable is not supported.
MPI startup(): Similar variables:
         I_MPI_MALLOC
MPI startup(): To check the list of supported variables, use the impi_info utility or refer to https://www.intel.com/content/www/us/en/docs/mpi-library/developer-reference-linux/
```